### PR TITLE
feat: migrate codebase to async functions

### DIFF
--- a/lib/__tests__/mocks.ts
+++ b/lib/__tests__/mocks.ts
@@ -73,19 +73,19 @@ export const getMockIdToken = (
 class ServerSessionManager implements SessionManager {
   private memCache: Record<string, unknown> = {};
 
-  destroySession(): void {
+  async destroySession(): Promise<void> {
     this.memCache = {};
   }
 
-  getSessionItem(itemKey: string) {
+  async getSessionItem(itemKey: string) {
     return this.memCache[itemKey] ?? null;
   }
 
-  setSessionItem(itemKey: string, itemValue: unknown): void {
+  async setSessionItem(itemKey: string, itemValue: unknown): Promise<void> {
     this.memCache[itemKey] = itemValue;
   }
 
-  removeSessionItem(itemKey: string): void {
+  async removeSessionItem(itemKey: string): Promise<void> {
     delete this.memCache[itemKey];
   }
 }

--- a/lib/__tests__/sdk/oauth2-flows/AuthCodeWithPKCE.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/AuthCodeWithPKCE.spec.ts
@@ -23,8 +23,8 @@ describe('AuthCodeWitPKCE', () => {
   });
 
   describe('createAuthorizationURL()', () => {
-    afterEach(() => {
-      sessionManager.destroySession();
+    afterEach(async () => {
+      await sessionManager.destroySession();
     });
 
     it('saves generated code verifier to session storage again state', async () => {
@@ -39,7 +39,7 @@ describe('AuthCodeWitPKCE', () => {
 
       const codeVerifierKey = `${AuthCodeWithPKCE.STATE_KEY}-${state!}`;
       const codeVerifierState = JSON.parse(
-        sessionManager.getSessionItem(codeVerifierKey)! as string
+        (await sessionManager.getSessionItem(codeVerifierKey)!) as string
       );
       expect(codeVerifierState).toBeDefined();
 
@@ -66,8 +66,8 @@ describe('AuthCodeWitPKCE', () => {
   });
 
   describe('handleRedirectFromAuthDomain()', () => {
-    afterEach(() => {
-      sessionManager.destroySession();
+    afterEach(async () => {
+      await sessionManager.destroySession();
       mocks.fetchClient.mockClear();
     });
 
@@ -100,7 +100,7 @@ describe('AuthCodeWitPKCE', () => {
       );
       const errorDescription = 'error_description';
       const codeVerifierKey = `${AuthCodeWithPKCE.STATE_KEY}-state`;
-      sessionManager.setSessionItem(
+      await sessionManager.setSessionItem(
         codeVerifierKey,
         JSON.stringify({ codeVerifier: 'code-verifier' })
       );
@@ -133,7 +133,7 @@ describe('AuthCodeWitPKCE', () => {
         `${clientConfig.redirectURL}?state=state&code=code`
       );
       const codeVerifierKey = `${AuthCodeWithPKCE.STATE_KEY}-state`;
-      sessionManager.setSessionItem(
+      await sessionManager.setSessionItem(
         codeVerifierKey,
         JSON.stringify({ codeVerifier: 'code-verifier' })
       );
@@ -142,9 +142,13 @@ describe('AuthCodeWitPKCE', () => {
       await client.handleRedirectFromAuthDomain(sessionManager, callbackURL);
       expect(mocks.fetchClient).toHaveBeenCalledTimes(1);
 
-      const foundRefreshToken = sessionManager.getSessionItem('refresh_token');
-      const foundAccessToken = sessionManager.getSessionItem('access_token');
-      const foundIdToken = sessionManager.getSessionItem('id_token');
+      const foundRefreshToken = await sessionManager.getSessionItem(
+        'refresh_token'
+      );
+      const foundAccessToken = await sessionManager.getSessionItem(
+        'access_token'
+      );
+      const foundIdToken = await sessionManager.getSessionItem('id_token');
 
       expect(foundAccessToken).toBe(mockAccessToken.token);
       expect(foundRefreshToken).toBe('refresh_token');
@@ -153,14 +157,17 @@ describe('AuthCodeWitPKCE', () => {
   });
 
   describe('getToken()', () => {
-    afterEach(() => {
-      sessionManager.destroySession();
+    afterEach(async () => {
+      await sessionManager.destroySession();
       mocks.fetchClient.mockClear();
     });
 
     it('return an existing token if an unexpired token is available', async () => {
       const mockAccessToken = mocks.getMockAccessToken(clientConfig.authDomain);
-      sessionManager.setSessionItem('access_token', mockAccessToken.token);
+      await sessionManager.setSessionItem(
+        'access_token',
+        mockAccessToken.token
+      );
       const client = new AuthCodeWithPKCE(clientConfig);
       const token = await client.getToken(sessionManager);
       expect(token).toBe(mockAccessToken.token);
@@ -172,7 +179,10 @@ describe('AuthCodeWitPKCE', () => {
         clientConfig.authDomain,
         true
       );
-      sessionManager.setSessionItem('access_token', mockAccessToken.token);
+      await sessionManager.setSessionItem(
+        'access_token',
+        mockAccessToken.token
+      );
       await expect(async () => {
         const client = new AuthCodeWithPKCE(clientConfig);
         await client.getToken(sessionManager);
@@ -194,8 +204,11 @@ describe('AuthCodeWitPKCE', () => {
         clientConfig.authDomain,
         true
       );
-      sessionManager.setSessionItem('access_token', expiredAccessToken.token);
-      sessionManager.setSessionItem('refresh_token', 'refresh_token');
+      await sessionManager.setSessionItem(
+        'access_token',
+        expiredAccessToken.token
+      );
+      await sessionManager.setSessionItem('refresh_token', 'refresh_token');
 
       const body = new URLSearchParams({
         grant_type: 'refresh_token',
@@ -233,8 +246,11 @@ describe('AuthCodeWitPKCE', () => {
         clientConfig.authDomain,
         true
       );
-      sessionManager.setSessionItem('access_token', expiredAccessToken.token);
-      sessionManager.setSessionItem('refresh_token', 'refresh_token');
+      await sessionManager.setSessionItem(
+        'access_token',
+        expiredAccessToken.token
+      );
+      await sessionManager.setSessionItem('refresh_token', 'refresh_token');
 
       const headerOverrides: SDKHeaderOverrideOptions = {
         framework: 'TypeScript-Framework',
@@ -276,16 +292,23 @@ describe('AuthCodeWitPKCE', () => {
         clientConfig.authDomain,
         true
       );
-      sessionManager.setSessionItem('access_token', expiredAccessToken.token);
-      sessionManager.setSessionItem('refresh_token', 'refresh_token');
+      await sessionManager.setSessionItem(
+        'access_token',
+        expiredAccessToken.token
+      );
+      await sessionManager.setSessionItem('refresh_token', 'refresh_token');
 
       const client = new AuthCodeWithPKCE(clientConfig);
       await client.getToken(sessionManager);
       expect(mocks.fetchClient).toHaveBeenCalledTimes(1);
 
-      const foundRefreshToken = sessionManager.getSessionItem('refresh_token');
-      const foundAccessToken = sessionManager.getSessionItem('access_token');
-      const foundIdToken = sessionManager.getSessionItem('id_token');
+      const foundRefreshToken = await sessionManager.getSessionItem(
+        'refresh_token'
+      );
+      const foundAccessToken = await sessionManager.getSessionItem(
+        'access_token'
+      );
+      const foundIdToken = await sessionManager.getSessionItem('id_token');
 
       expect(foundAccessToken).toBe(newAccessToken.token);
       expect(foundRefreshToken).toBe(newRefreshToken);

--- a/lib/__tests__/sdk/oauth2-flows/AuthCodeWithPKCE.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/AuthCodeWithPKCE.spec.ts
@@ -39,7 +39,7 @@ describe('AuthCodeWitPKCE', () => {
 
       const codeVerifierKey = `${AuthCodeWithPKCE.STATE_KEY}-${state!}`;
       const codeVerifierState = JSON.parse(
-        (await sessionManager.getSessionItem(codeVerifierKey)!) as string
+        (await sessionManager.getSessionItem(codeVerifierKey)) as string
       );
       expect(codeVerifierState).toBeDefined();
 

--- a/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
@@ -27,8 +27,8 @@ describe('AuthorizationCode', () => {
   });
 
   describe('createAuthorizationURL()', () => {
-    afterEach(() => {
-      sessionManager.destroySession();
+    afterEach(async () => {
+      await sessionManager.destroySession();
     });
 
     it('uses default scopes if none is provided in the url options', async () => {
@@ -82,7 +82,9 @@ describe('AuthorizationCode', () => {
       const searchParams = new URLSearchParams(authURL.search);
       const state = searchParams.get('state');
       const stateKey = AuthorizationCode.STATE_KEY;
-      const storedState = sessionManager.getSessionItem(stateKey)! as string;
+      const storedState = (await sessionManager.getSessionItem(
+        stateKey
+      )!) as string;
       expect(storedState).toBe(state);
     });
 
@@ -99,9 +101,9 @@ describe('AuthorizationCode', () => {
   });
 
   describe('handleRedirectFromAuthDomain()', () => {
-    afterEach(() => {
+    afterEach(async () => {
       mocks.fetchClient.mockClear();
-      sessionManager.destroySession();
+      await sessionManager.destroySession();
     });
 
     it('throws an error if callbackURL has an error query param', async () => {
@@ -132,7 +134,7 @@ describe('AuthorizationCode', () => {
         `${clientConfig.redirectURL}?state=state&code=code`
       );
       const errorDescription = 'error_description';
-      sessionManager.setSessionItem(AuthorizationCode.STATE_KEY, 'state');
+      await sessionManager.setSessionItem(AuthorizationCode.STATE_KEY, 'state');
       mocks.fetchClient.mockResolvedValue({
         json: () => ({
           error: 'error',
@@ -162,14 +164,18 @@ describe('AuthorizationCode', () => {
         `${clientConfig.redirectURL}?state=state&code=code`
       );
       const stateKey = AuthorizationCode.STATE_KEY;
-      sessionManager.setSessionItem(stateKey, 'state');
+      await sessionManager.setSessionItem(stateKey, 'state');
       const client = new AuthorizationCode(clientConfig, clientSecret);
       await client.handleRedirectFromAuthDomain(sessionManager, callbackURL);
       expect(mocks.fetchClient).toHaveBeenCalledTimes(1);
 
-      const foundRefreshToken = sessionManager.getSessionItem('refresh_token');
-      const foundAccessToken = sessionManager.getSessionItem('access_token');
-      const foundIdToken = sessionManager.getSessionItem('id_token');
+      const foundRefreshToken = await sessionManager.getSessionItem(
+        'refresh_token'
+      );
+      const foundAccessToken = await sessionManager.getSessionItem(
+        'access_token'
+      );
+      const foundIdToken = await sessionManager.getSessionItem('id_token');
 
       expect(foundAccessToken).toBe(mockAccessToken.token);
       expect(foundRefreshToken).toBe('refresh_token');
@@ -178,14 +184,17 @@ describe('AuthorizationCode', () => {
   });
 
   describe('getToken()', () => {
-    afterEach(() => {
+    afterEach(async () => {
       mocks.fetchClient.mockClear();
-      sessionManager.destroySession();
+      await sessionManager.destroySession();
     });
 
     it('return an existing token if an unexpired token is available', async () => {
       const mockAccessToken = mocks.getMockAccessToken(clientConfig.authDomain);
-      sessionManager.setSessionItem('access_token', mockAccessToken.token);
+      await sessionManager.setSessionItem(
+        'access_token',
+        mockAccessToken.token
+      );
       const client = new AuthorizationCode(clientConfig, clientSecret);
       const token = await client.getToken(sessionManager);
       expect(token).toBe(mockAccessToken.token);
@@ -204,7 +213,10 @@ describe('AuthorizationCode', () => {
         clientConfig.authDomain,
         true
       );
-      sessionManager.setSessionItem('access_token', mockAccessToken.token);
+      await sessionManager.setSessionItem(
+        'access_token',
+        mockAccessToken.token
+      );
       await expect(async () => {
         const client = new AuthorizationCode(clientConfig, clientSecret);
         await client.getToken(sessionManager);
@@ -224,8 +236,11 @@ describe('AuthorizationCode', () => {
         clientConfig.authDomain,
         true
       );
-      sessionManager.setSessionItem('access_token', expiredAccessToken.token);
-      sessionManager.setSessionItem('refresh_token', 'refresh_token');
+      await sessionManager.setSessionItem(
+        'access_token',
+        expiredAccessToken.token
+      );
+      await sessionManager.setSessionItem('refresh_token', 'refresh_token');
 
       await expect(async () => {
         const client = new AuthorizationCode(clientConfig, clientSecret);
@@ -249,8 +264,11 @@ describe('AuthorizationCode', () => {
         clientConfig.authDomain,
         true
       );
-      sessionManager.setSessionItem('access_token', expiredAccessToken.token);
-      sessionManager.setSessionItem('refresh_token', 'refresh_token');
+      await sessionManager.setSessionItem(
+        'access_token',
+        expiredAccessToken.token
+      );
+      await sessionManager.setSessionItem('refresh_token', 'refresh_token');
 
       const body = new URLSearchParams({
         grant_type: 'refresh_token',
@@ -289,8 +307,11 @@ describe('AuthorizationCode', () => {
         clientConfig.authDomain,
         true
       );
-      sessionManager.setSessionItem('access_token', expiredAccessToken.token);
-      sessionManager.setSessionItem('refresh_token', 'refresh_token');
+      await sessionManager.setSessionItem(
+        'access_token',
+        expiredAccessToken.token
+      );
+      await sessionManager.setSessionItem('refresh_token', 'refresh_token');
 
       const headerOverrides: SDKHeaderOverrideOptions = {
         framework: 'TypeScript-Framework',
@@ -335,16 +356,23 @@ describe('AuthorizationCode', () => {
         clientConfig.authDomain,
         true
       );
-      sessionManager.setSessionItem('access_token', expiredAccessToken.token);
-      sessionManager.setSessionItem('refresh_token', 'refresh_token');
+      await sessionManager.setSessionItem(
+        'access_token',
+        expiredAccessToken.token
+      );
+      await sessionManager.setSessionItem('refresh_token', 'refresh_token');
 
       const client = new AuthorizationCode(clientConfig, clientSecret);
       await client.getToken(sessionManager);
       expect(mocks.fetchClient).toHaveBeenCalledTimes(1);
 
-      const foundRefreshToken = sessionManager.getSessionItem('refresh_token');
-      const foundAccessToken = sessionManager.getSessionItem('access_token');
-      const foundIdToken = sessionManager.getSessionItem('id_token');
+      const foundRefreshToken = await sessionManager.getSessionItem(
+        'refresh_token'
+      );
+      const foundAccessToken = await sessionManager.getSessionItem(
+        'access_token'
+      );
+      const foundIdToken = await sessionManager.getSessionItem('id_token');
 
       expect(foundAccessToken).toBe(newAccessToken.token);
       expect(foundRefreshToken).toBe(newRefreshToken);
@@ -353,14 +381,17 @@ describe('AuthorizationCode', () => {
   });
 
   describe('getUserProfile()', () => {
-    afterEach(() => {
+    afterEach(async () => {
       mocks.fetchClient.mockClear();
-      sessionManager.destroySession();
+      await sessionManager.destroySession();
     });
 
     it('fetches user profile using the available access token', async () => {
       const mockAccessToken = mocks.getMockAccessToken(clientConfig.authDomain);
-      sessionManager.setSessionItem('access_token', mockAccessToken.token);
+      await sessionManager.setSessionItem(
+        'access_token',
+        mockAccessToken.token
+      );
 
       const headers = new Headers();
       headers.append('Authorization', `Bearer ${mockAccessToken.token}`);
@@ -386,7 +417,10 @@ describe('AuthorizationCode', () => {
 
     it('commits fetched user details to memory store', async () => {
       const mockAccessToken = mocks.getMockAccessToken(clientConfig.authDomain);
-      sessionManager.setSessionItem('access_token', mockAccessToken.token);
+      await sessionManager.setSessionItem(
+        'access_token',
+        mockAccessToken.token
+      );
       const userDetails = {
         family_name: 'family_name',
         given_name: 'give_name',
@@ -402,7 +436,9 @@ describe('AuthorizationCode', () => {
       const client = new AuthorizationCode(clientConfig, clientSecret);
       await client.getUserProfile(sessionManager);
       expect(mocks.fetchClient).toHaveBeenCalledTimes(1);
-      expect(sessionManager.getSessionItem('user')).toStrictEqual(userDetails);
+      expect(await sessionManager.getSessionItem('user')).toStrictEqual(
+        userDetails
+      );
     });
   });
 });

--- a/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
@@ -84,7 +84,7 @@ describe('AuthorizationCode', () => {
       const stateKey = AuthorizationCode.STATE_KEY;
       const storedState = (await sessionManager.getSessionItem(
         stateKey
-      )!) as string;
+      )) as string;
       expect(storedState).toBe(state);
     });
 

--- a/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
@@ -37,8 +37,8 @@ describe('ClientCredentials', () => {
       'application/x-www-form-urlencoded; charset=UTF-8'
     );
 
-    afterEach(() => {
-      sessionManager.destroySession();
+    afterEach(async () => {
+      await sessionManager.destroySession();
       mocks.fetchClient.mockClear();
     });
 
@@ -61,7 +61,11 @@ describe('ClientCredentials', () => {
     it('return access token if an unexpired token is available in memory', async () => {
       const { authDomain } = clientConfig;
       const { token: mockAccessToken } = mocks.getMockAccessToken(authDomain);
-      commitTokenToMemory(sessionManager, mockAccessToken, 'access_token');
+      await commitTokenToMemory(
+        sessionManager,
+        mockAccessToken,
+        'access_token'
+      );
 
       const client = new ClientCredentials(clientConfig);
       const accessToken = await client.getToken(sessionManager);
@@ -144,7 +148,7 @@ describe('ClientCredentials', () => {
       const client = new ClientCredentials(clientConfig);
       await client.getToken(sessionManager);
       expect(mocks.fetchClient).toHaveBeenCalledTimes(1);
-      expect(sessionManager.getSessionItem('access_token')).toBe(
+      expect(await sessionManager.getSessionItem('access_token')).toBe(
         mockAccessToken
       );
     });

--- a/lib/__tests__/sdk/session-managers/BrowserSessionManager.browser.spec.ts
+++ b/lib/__tests__/sdk/session-managers/BrowserSessionManager.browser.spec.ts
@@ -7,8 +7,8 @@ import { BrowserSessionManager } from '../../../sdk/session-managers';
 describe('BrowserSessionManager', () => {
   const sessionManager = new BrowserSessionManager();
 
-  afterEach(() => {
-    sessionManager.destroySession();
+  afterEach(async () => {
+    await sessionManager.destroySession();
   });
 
   describe('new BrowserSessionManager()', () => {
@@ -18,59 +18,67 @@ describe('BrowserSessionManager', () => {
   });
 
   describe('destroySession()', () => {
-    it('clears all items in session after being called', () => {
+    it('clears all items in session after being called', async () => {
       const sessionItemKey = 'session-item-key';
-      sessionManager.setSessionItem(sessionItemKey, 'session-key-value');
-      sessionManager.destroySession();
-      expect(sessionManager.getSessionItem(sessionItemKey)).toBe(null);
+      await sessionManager.setSessionItem(sessionItemKey, 'session-key-value');
+      await sessionManager.destroySession();
+      expect(await sessionManager.getSessionItem(sessionItemKey)).toBe(null);
     });
   });
 
   describe('setSessionItem()', () => {
-    it('stores a value against the provided key in memory', () => {
+    it('stores a value against the provided key in memory', async () => {
       const sessionItemKey = 'session-item-key';
       const sessionItemValue = 'session-item-value';
-      sessionManager.setSessionItem(sessionItemKey, sessionItemValue);
-      expect(sessionManager.getSessionItem(sessionItemKey)).toBe(
+      await sessionManager.setSessionItem(sessionItemKey, sessionItemValue);
+      expect(await sessionManager.getSessionItem(sessionItemKey)).toBe(
         sessionItemValue
       );
     });
   });
 
   describe('removeSessionItem()', () => {
-    it('removes a session item from memory', () => {
+    it('removes a session item from memory', async () => {
       const sessionItemKey = 'session-item-key';
       const sessionItemValue = 'session-item-value';
-      sessionManager.setSessionItem(sessionItemKey, sessionItemValue);
-      expect(sessionManager.getSessionItem(sessionItemKey)).toBe(
+      await sessionManager.setSessionItem(sessionItemKey, sessionItemValue);
+      expect(await sessionManager.getSessionItem(sessionItemKey)).toBe(
         sessionItemValue
       );
-      sessionManager.removeSessionItem(sessionItemKey);
-      expect(sessionManager.getSessionItem(sessionItemKey)).toBe(null);
+      await sessionManager.removeSessionItem(sessionItemKey);
+      expect(await sessionManager.getSessionItem(sessionItemKey)).toBe(null);
     });
   });
 
   describe('setBrowserSessionItem()', () => {
-    it('stores a value against the provided key in the browser\'s session storage', () => {
+    it('stores a value against the provided key in the browser\'s session storage', async () => {
       const sessionItemKey = 'session-item-key';
       const sessionItemValue = 'session-item-value';
-      sessionManager.setSessionItemBrowser(sessionItemKey, sessionItemValue);
-      expect(sessionManager.getSessionItemBrowser(sessionItemKey)).toBe(
+      await sessionManager.setSessionItemBrowser(
+        sessionItemKey,
+        sessionItemValue
+      );
+      expect(await sessionManager.getSessionItemBrowser(sessionItemKey)).toBe(
         sessionItemValue
       );
     });
   });
 
   describe('removeBrowserSessionItem()', () => {
-    it('removes a session item from the browser\'s session storage', () => {
+    it('removes a session item from the browser\'s session storage', async () => {
       const sessionItemKey = 'session-item-key';
       const sessionItemValue = 'session-item-value';
-      sessionManager.setSessionItemBrowser(sessionItemKey, sessionItemValue);
-      expect(sessionManager.getSessionItemBrowser(sessionItemKey)).toBe(
+      await sessionManager.setSessionItemBrowser(
+        sessionItemKey,
         sessionItemValue
       );
-      sessionManager.removeSessionItemBrowser(sessionItemKey);
-      expect(sessionManager.getSessionItemBrowser(sessionItemKey)).toBe(null);
+      expect(await sessionManager.getSessionItemBrowser(sessionItemKey)).toBe(
+        sessionItemValue
+      );
+      await sessionManager.removeSessionItemBrowser(sessionItemKey);
+      expect(await sessionManager.getSessionItemBrowser(sessionItemKey)).toBe(
+        null
+      );
     });
   });
 });

--- a/lib/__tests__/sdk/utilities/feature-flags.spec.ts
+++ b/lib/__tests__/sdk/utilities/feature-flags.spec.ts
@@ -10,35 +10,39 @@ describe('feature-flags', () => {
   let mockAccessToken: ReturnType<typeof mocks.getMockAccessToken>;
   const { sessionManager } = mocks;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mockAccessToken = mocks.getMockAccessToken();
-    sessionManager.setSessionItem(
+    await sessionManager.setSessionItem(
       'access_token_payload',
       mockAccessToken.payload
     );
-    sessionManager.setSessionItem('access_token', mockAccessToken.token);
+    await sessionManager.setSessionItem('access_token', mockAccessToken.token);
   });
 
-  afterEach(() => {
-    sessionManager.destroySession();
+  afterEach(async () => {
+    await sessionManager.destroySession();
   });
 
   describe('getFlag', () => {
-    it('throws error if no flag is found no defaultValue is given', () => {
+    it('throws error if no flag is found no defaultValue is given', async () => {
       const code = 'non-existant-code';
-      expect(() => getFlag(sessionManager, code)).toThrowError(
+      await expect(
+        async () => await getFlag(sessionManager, code)
+      ).rejects.toThrowError(
         new Error(
           `Flag ${code} was not found, and no default value has been provided`
         )
       );
     });
 
-    it('throw error if provided type is different from typeof of found flag', () => {
+    it('throw error if provided type is different from typeof of found flag', async () => {
       const featureFlags = mockAccessToken.payload
         .feature_flags as FeatureFlags;
       const code = 'is_dark_mode';
       const flag = featureFlags[code];
-      expect(() => getFlag(sessionManager, code, true, 's')).toThrowError(
+      await expect(
+        async () => await getFlag(sessionManager, code, true, 's')
+      ).rejects.toThrowError(
         new Error(
           `Flag ${code} is of type ${FlagDataType[flag!.t]}, expected type is ${
             FlagDataType.s
@@ -50,36 +54,38 @@ describe('feature-flags', () => {
     it('should not throw error for falsy default value which is not `undefined`', () => {
       const code = 'non-existant-code';
       const getFlagFnArray = [
-        () => getFlag(sessionManager, code, false, 'b'),
-        () => getFlag(sessionManager, code, '', 's'),
-        () => getFlag(sessionManager, code, 0, 'i'),
+        async () => await getFlag(sessionManager, code, false, 'b'),
+        async () => await getFlag(sessionManager, code, '', 's'),
+        async () => await getFlag(sessionManager, code, 0, 'i'),
       ];
 
-      getFlagFnArray.forEach(getFlagFn => expect(getFlagFn).not.toThrow());
+      getFlagFnArray.forEach((getFlagFn) => {
+        expect(getFlagFn).not.toThrow();
+      });
     });
 
-    it('provide result contains no type if default-value is used', () => {
+    it('provide result contains no type if default-value is used', async () => {
       const defaultValue = 'default-value';
       const code = 'non-existant-code';
-      expect(getFlag(sessionManager, code, defaultValue)).toStrictEqual({
+      expect(await getFlag(sessionManager, code, defaultValue)).toStrictEqual({
         value: defaultValue,
         is_default: true,
         code,
       });
     });
 
-    it('retrieves flag data for a defined feature flag', () => {
+    it('retrieves flag data for a defined feature flag', async () => {
       const featureFlags = mockAccessToken.payload
         .feature_flags as FeatureFlags;
-      Object.keys(featureFlags).forEach((code) => {
+      for (const code in featureFlags) {
         const flag = featureFlags[code];
-        expect(getFlag(sessionManager, code)).toStrictEqual({
+        expect(await getFlag(sessionManager, code)).toStrictEqual({
           is_default: false,
           value: flag!.v,
           type: FlagDataType[flag!.t],
           code,
         });
-      });
+      }
     });
   });
 });

--- a/lib/__tests__/sdk/utilities/token-utils.spec.ts
+++ b/lib/__tests__/sdk/utilities/token-utils.spec.ts
@@ -12,7 +12,7 @@ describe('token-utils', () => {
   const { sessionManager } = mocks;
 
   describe('commitTokensToMemory', () => {
-    it('stores all provided tokens to memory', () => {
+    it('stores all provided tokens to memory', async () => {
       const { token: mockAccessToken } = mocks.getMockAccessToken(domain);
       const { token: mockIdToken } = mocks.getMockAccessToken(domain);
       const tokenCollection: TokenCollection = {
@@ -20,37 +20,41 @@ describe('token-utils', () => {
         access_token: mockAccessToken,
         id_token: mockIdToken,
       };
-      commitTokensToMemory(sessionManager, tokenCollection);
+      await commitTokensToMemory(sessionManager, tokenCollection);
 
-      expect(sessionManager.getSessionItem('refresh_token')).toBe(
+      expect(await sessionManager.getSessionItem('refresh_token')).toBe(
         tokenCollection.refresh_token
       );
-      expect(sessionManager.getSessionItem('access_token')).toBe(
+      expect(await sessionManager.getSessionItem('access_token')).toBe(
         mockAccessToken
       );
-      expect(sessionManager.getSessionItem('id_token')).toBe(mockIdToken);
+      expect(await sessionManager.getSessionItem('id_token')).toBe(mockIdToken);
     });
   });
 
   describe('commitTokenToMemory()', () => {
-    afterEach(() => {
-      sessionManager.destroySession();
+    afterEach(async () => {
+      await sessionManager.destroySession();
     });
 
-    it('stores provided token to memory', () => {
+    it('stores provided token to memory', async () => {
       const { token: mockAccessToken } = mocks.getMockAccessToken(domain);
-      commitTokenToMemory(sessionManager, mockAccessToken, 'access_token');
-      expect(sessionManager.getSessionItem('access_token')).toBe(
+      await commitTokenToMemory(
+        sessionManager,
+        mockAccessToken,
+        'access_token'
+      );
+      expect(await sessionManager.getSessionItem('access_token')).toBe(
         mockAccessToken
       );
     });
 
-    it('stores user information if provide token is an id token', () => {
+    it('stores user information if provide token is an id token', async () => {
       const { token: mockIdToken, payload: idTokenPayload } =
         mocks.getMockIdToken(domain);
-      commitTokenToMemory(sessionManager, mockIdToken, 'id_token');
+      await commitTokenToMemory(sessionManager, mockIdToken, 'id_token');
 
-      const storedUser = sessionManager.getSessionItem('user');
+      const storedUser = await sessionManager.getSessionItem('user');
       const expectedUser = {
         family_name: idTokenPayload.family_name,
         given_name: idTokenPayload.given_name,
@@ -59,7 +63,7 @@ describe('token-utils', () => {
         picture: null,
       };
 
-      expect(sessionManager.getSessionItem('id_token')).toBe(mockIdToken);
+      expect(await sessionManager.getSessionItem('id_token')).toBe(mockIdToken);
       expect(storedUser).toStrictEqual(expectedUser);
     });
   });

--- a/lib/sdk/clients/browser/authcode-with-pkce.ts
+++ b/lib/sdk/clients/browser/authcode-with-pkce.ts
@@ -102,7 +102,7 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
         'Cannot get user details, no authentication credential found'
       );
     }
-    return utilities.getUserFromMemory(sessionManager)!;
+    return (await utilities.getUserFromMemory(sessionManager))!;
   };
 
   /**
@@ -112,8 +112,15 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    * @param {number} defaultValue
    * @returns {number} integer flag value
    */
-  const getIntegerFlag = (code: string, defaultValue?: number): number => {
-    return featureFlags.getIntegerFlag(sessionManager, code, defaultValue);
+  const getIntegerFlag = async (
+    code: string,
+    defaultValue?: number
+  ): Promise<number> => {
+    return await featureFlags.getIntegerFlag(
+      sessionManager,
+      code,
+      defaultValue
+    );
   };
 
   /**
@@ -123,8 +130,11 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    * @param {string} defaultValue
    * @returns {string} string flag value
    */
-  const getStringFlag = (code: string, defaultValue?: string): string => {
-    return featureFlags.getStringFlag(sessionManager, code, defaultValue);
+  const getStringFlag = async (
+    code: string,
+    defaultValue?: string
+  ): Promise<string> => {
+    return await featureFlags.getStringFlag(sessionManager, code, defaultValue);
   };
 
   /**
@@ -134,8 +144,15 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    * @param {boolean} defaultValue
    * @returns {boolean} boolean flag value
    */
-  const getBooleanFlag = (code: string, defaultValue?: boolean): boolean => {
-    return featureFlags.getBooleanFlag(sessionManager, code, defaultValue);
+  const getBooleanFlag = async (
+    code: string,
+    defaultValue?: boolean
+  ): Promise<boolean> => {
+    return await featureFlags.getBooleanFlag(
+      sessionManager,
+      code,
+      defaultValue
+    );
   };
 
   /**
@@ -159,11 +176,11 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    * @param {ClaimTokenType} type
    * @returns {{ name: string, value: unknown | null }}
    */
-  const getClaim = (
+  const getClaim = async (
     claim: string,
     type: ClaimTokenType = 'access_token'
-  ): { name: string; value: unknown | null } => {
-    return tokenClaims.getClaim(sessionManager, claim, type);
+  ): Promise<{ name: string; value: unknown | null }> => {
+    return await tokenClaims.getClaim(sessionManager, claim, type);
   };
 
   /**
@@ -173,18 +190,18 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    * @param {string} name
    * @returns {{ orgCode: string | null, isGranted: boolean }}
    */
-  const getPermission = (
+  const getPermission = async (
     name: string
-  ): { orgCode: string | null; isGranted: boolean } => {
-    return tokenClaims.getPermission(sessionManager, name);
+  ): Promise<{ orgCode: string | null; isGranted: boolean }> => {
+    return await tokenClaims.getPermission(sessionManager, name);
   };
 
   /**
    * Method extracts the organization code from the current session.
    * @returns {{ orgCode: string | null }}
    */
-  const getOrganization = (): { orgCode: string | null } => {
-    return tokenClaims.getOrganization(sessionManager);
+  const getOrganization = async (): Promise<{ orgCode: string | null }> => {
+    return await tokenClaims.getOrganization(sessionManager);
   };
 
   /**
@@ -192,8 +209,8 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    * session.
    * @returns {{ orgCodes: string[] }}
    */
-  const getUserOrganizations = (): { orgCodes: string[] } => {
-    return tokenClaims.getUserOrganizations(sessionManager);
+  const getUserOrganizations = async (): Promise<{ orgCodes: string[] }> => {
+    return await tokenClaims.getUserOrganizations(sessionManager);
   };
 
   /**
@@ -201,11 +218,11 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    * token in the current session.
    * @returns {{ permissions: string[], orgCode: string | null }}
    */
-  const getPermissions = (): {
+  const getPermissions = async (): Promise<{
     permissions: string[];
     orgCode: string | null;
-  } => {
-    return tokenClaims.getPermissions(sessionManager);
+  }> => {
+    return await tokenClaims.getPermissions(sessionManager);
   };
 
   /**
@@ -225,12 +242,12 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    * @param {keyof FlagType} type
    * @returns {GetFlagType}
    */
-  const getFlag = (
+  const getFlag = async (
     code: string,
     defaultValue?: FlagType[keyof FlagType],
     type?: keyof FlagType
-  ): GetFlagType => {
-    return featureFlags.getFlag(sessionManager, code, defaultValue, type);
+  ): Promise<GetFlagType> => {
+    return await featureFlags.getFlag(sessionManager, code, defaultValue, type);
   };
 
   /**
@@ -238,8 +255,8 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    * to which will clear the user's session on the authorization server.
    * @returns {URL}
    */
-  const logout = (): URL => {
-    sessionManager.destroySession();
+  const logout = async (): Promise<URL> => {
+    await sessionManager.destroySession();
     return new URL(client.logoutEndpoint);
   };
 

--- a/lib/sdk/clients/server/authorization-code.ts
+++ b/lib/sdk/clients/server/authorization-code.ts
@@ -122,7 +122,7 @@ const createAuthorizationCodeClient = (
         'Cannot get user details, no authentication credential found'
       );
     }
-    return utilities.getUserFromMemory(sessionManager)!;
+    return (await utilities.getUserFromMemory(sessionManager))!;
   };
 
   /**
@@ -141,8 +141,8 @@ const createAuthorizationCodeClient = (
    * @param {SessionManager} sessionManager
    * @returns {URL}
    */
-  const logout = (sessionManager: SessionManager): URL => {
-    sessionManager.destroySession();
+  const logout = async (sessionManager: SessionManager): Promise<URL> => {
+    await sessionManager.destroySession();
     return new URL(client.logoutEndpoint);
   };
 

--- a/lib/sdk/clients/server/client-credentials.ts
+++ b/lib/sdk/clients/server/client-credentials.ts
@@ -12,8 +12,8 @@ const createCCClient = (options: CCClientOptions) => {
    * @param {SessionManager} sessionManager
    * @returns {URL}
    */
-  const logout = (sessionManager: SessionManager): URL => {
-    sessionManager.destroySession();
+  const logout = async (sessionManager: SessionManager): Promise<URL> => {
+    await sessionManager.destroySession();
     return new URL(client.logoutEndpoint);
   };
 

--- a/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
@@ -94,7 +94,7 @@ export abstract class AuthCodeAbstract {
       sessionManager,
       callbackURL
     );
-    utilities.commitTokensToMemory(sessionManager, tokens);
+    await utilities.commitTokensToMemory(sessionManager, tokens);
   }
 
   /**
@@ -106,7 +106,7 @@ export abstract class AuthCodeAbstract {
    * @returns {Promise<string>}
    */
   public async getToken(sessionManager: SessionManager): Promise<string> {
-    const accessToken = utilities.getAccessToken(sessionManager);
+    const accessToken = await utilities.getAccessToken(sessionManager);
     if (!accessToken) {
       throw new Error('No authentication credential found');
     }
@@ -116,7 +116,7 @@ export abstract class AuthCodeAbstract {
       return accessToken;
     }
 
-    const refreshToken = utilities.getRefreshToken(sessionManager);
+    const refreshToken = await utilities.getRefreshToken(sessionManager);
     if (!refreshToken && isNodeEnvironment()) {
       throw Error('Cannot persist session no valid refresh token found');
     }
@@ -159,7 +159,7 @@ export abstract class AuthCodeAbstract {
     const config: RequestInit = { method: 'GET', headers };
     const response = await fetch(targetURL, config);
     const payload = (await response.json()) as UserType;
-    utilities.commitUserToMemory(sessionManager, payload);
+    await utilities.commitUserToMemory(sessionManager, payload);
     return payload;
   }
 
@@ -222,7 +222,7 @@ export abstract class AuthCodeAbstract {
 
     const errorPayload = payload as OAuth2CodeExchangeErrorResponse;
     if (errorPayload.error) {
-      sessionManager.destroySession();
+      await sessionManager.destroySession();
       const errorDescription = errorPayload.error_description;
       const message = errorDescription ?? errorPayload.error;
       throw new Error(message);

--- a/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
@@ -53,7 +53,7 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
           .setSessionItemBrowser
       : sessionManager.setSessionItem;
 
-    setItem.call(
+    await setItem.call(
       sessionManager,
       this.getCodeVerifierKey(this.state),
       JSON.stringify({ codeVerifier: this.codeVerifier })
@@ -75,7 +75,7 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
   protected async refreshTokens(
     sessionManager: SessionManager
   ): Promise<OAuth2CodeExchangeResponse> {
-    const refreshToken = utilities.getRefreshToken(sessionManager);
+    const refreshToken = await utilities.getRefreshToken(sessionManager);
     const body = new URLSearchParams({
       grant_type: 'refresh_token',
       refresh_token: refreshToken!,
@@ -83,7 +83,7 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
     });
 
     const tokens = await this.fetchTokensFor(sessionManager, body, true);
-    utilities.commitTokensToMemory(sessionManager, tokens);
+    await utilities.commitTokensToMemory(sessionManager, tokens);
     return tokens;
   }
 
@@ -110,7 +110,7 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
           .getSessionItemBrowser
       : sessionManager.getSessionItem;
 
-    const storedState = getItem.call(sessionManager, storedStateKey) as
+    const storedState = (await getItem.call(sessionManager, storedStateKey)) as
       | string
       | null;
     if (!storedState) {
@@ -136,7 +136,7 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
     try {
       return await this.fetchTokensFor(sessionManager, body);
     } finally {
-      removeItem.call(sessionManager, this.getCodeVerifierKey(state));
+      await removeItem.call(sessionManager, this.getCodeVerifierKey(state));
     }
   }
 

--- a/lib/sdk/oauth2-flows/ClientCredentials.ts
+++ b/lib/sdk/oauth2-flows/ClientCredentials.ts
@@ -32,14 +32,14 @@ export class ClientCredentials {
    * @returns {Promise<string>}
    */
   async getToken(sessionManager: SessionManager): Promise<string> {
-    const accessToken = utilities.getAccessToken(sessionManager);
+    const accessToken = await utilities.getAccessToken(sessionManager);
     const isTokenExpired = utilities.isTokenExpired(accessToken);
     if (accessToken && !isTokenExpired) {
       return accessToken;
     }
 
     const payload = await this.fetchAccessTokenFor(sessionManager);
-    utilities.commitTokenToMemory(
+    await utilities.commitTokenToMemory(
       sessionManager,
       payload.access_token,
       'access_token'
@@ -76,7 +76,7 @@ export class ClientCredentials {
 
     const errorPayload = payload as OAuth2CCTokenErrorResponse;
     if (errorPayload.error) {
-      sessionManager.destroySession();
+      await sessionManager.destroySession();
       const errorDescription = errorPayload.error_description;
       const message = errorDescription ?? errorPayload.error;
       throw new Error(message);

--- a/lib/sdk/session-managers/BrowserSessionManager.ts
+++ b/lib/sdk/session-managers/BrowserSessionManager.ts
@@ -30,7 +30,7 @@ export class BrowserSessionManager implements SessionManager {
    * Clears all items from session store.
    * @returns {void}
    */
-  destroySession(): void {
+  async destroySession(): Promise<void> {
     sessionStorage.clear();
     this.memCache = {};
   }
@@ -41,7 +41,7 @@ export class BrowserSessionManager implements SessionManager {
    * @param {unknown} itemValue
    * @returns {void}
    */
-  setSessionItem(itemKey: string, itemValue: unknown): void {
+  async setSessionItem(itemKey: string, itemValue: unknown): Promise<void> {
     const key = this.generateItemKey(itemKey);
     this.memCache[key] = itemValue;
   }
@@ -51,7 +51,10 @@ export class BrowserSessionManager implements SessionManager {
    * @param {string} itemKey
    * @param {unknown} itemValue
    */
-  setSessionItemBrowser(itemKey: string, itemValue: unknown): void {
+  async setSessionItemBrowser(
+    itemKey: string,
+    itemValue: unknown
+  ): Promise<void> {
     const key = this.generateItemKey(itemKey);
     const isString = typeof itemValue === 'string';
     const value = !isString ? JSON.stringify(itemValue) : itemValue;
@@ -63,7 +66,7 @@ export class BrowserSessionManager implements SessionManager {
    * @param {string} itemKey
    * @returns {unknown | null}
    */
-  getSessionItem(itemKey: string): unknown | null {
+  async getSessionItem(itemKey: string): Promise<unknown | null> {
     const key = this.generateItemKey(itemKey);
     return this.memCache[key] ?? null;
   }
@@ -73,7 +76,7 @@ export class BrowserSessionManager implements SessionManager {
    * @param {string} itemKey
    * @returns {unknown | null}
    */
-  getSessionItemBrowser(itemKey: string): unknown | null {
+  async getSessionItemBrowser(itemKey: string): Promise<unknown | null> {
     const key = this.generateItemKey(itemKey);
     return sessionStorage.getItem(key);
   }
@@ -83,7 +86,7 @@ export class BrowserSessionManager implements SessionManager {
    * @param {string} itemKey
    * @returns {void}
    */
-  removeSessionItem(itemKey: string): void {
+  async removeSessionItem(itemKey: string): Promise<void> {
     const key = this.generateItemKey(itemKey);
     delete this.memCache[key];
   }
@@ -93,7 +96,7 @@ export class BrowserSessionManager implements SessionManager {
    * @param {string} itemKey
    * @returns {void}
    */
-  removeSessionItemBrowser(itemKey: string): void {
+  async removeSessionItemBrowser(itemKey: string): Promise<void> {
     const key = this.generateItemKey(itemKey);
     sessionStorage.removeItem(key);
   }

--- a/lib/sdk/session-managers/types.ts
+++ b/lib/sdk/session-managers/types.ts
@@ -3,9 +3,11 @@
  * satisfiy in order to work with this SDK, please vist the example provided in the
  * README, to understand how this works.
  */
+type Awaitable<T> = Promise<T>;
+
 export interface SessionManager {
-  getSessionItem: (itemKey: string) => unknown | null;
-  setSessionItem: (itemKey: string, itemValue: unknown) => void;
-  removeSessionItem: (itemKey: string) => void;
-  destroySession: () => void;
+  getSessionItem: (itemKey: string) => Awaitable<unknown | null>;
+  setSessionItem: (itemKey: string, itemValue: unknown) => Awaitable<void>;
+  removeSessionItem: (itemKey: string) => Awaitable<void>;
+  destroySession: () => Awaitable<void>;
 }

--- a/lib/sdk/utilities/feature-flags.ts
+++ b/lib/sdk/utilities/feature-flags.ts
@@ -17,14 +17,15 @@ import {
  * @param {keyof FlagType} type
  * @returns {GetFlagType}
  */
-export const getFlag = (
+export const getFlag = async (
   sessionManager: SessionManager,
   code: string,
   defaultValue?: FlagType[keyof FlagType],
   type?: keyof FlagType
-): GetFlagType => {
+): Promise<GetFlagType> => {
   const featureFlags =
-    (getClaimValue(sessionManager, 'feature_flags') as FeatureFlags) ?? {};
+    ((await getClaimValue(sessionManager, 'feature_flags')) as FeatureFlags) ??
+    {};
   const flag = featureFlags[code];
 
   if (!flag && defaultValue === undefined) {
@@ -62,12 +63,13 @@ export const getFlag = (
  * @param {number} defaultValue
  * @returns {number} integer flag value
  */
-export const getIntegerFlag = (
+export const getIntegerFlag = async (
   sessionManager: SessionManager,
   code: string,
   defaultValue?: number
-): number => {
-  return getFlag(sessionManager, code, defaultValue, 'i').value as number;
+): Promise<number> => {
+  return (await getFlag(sessionManager, code, defaultValue, 'i'))
+    .value as number;
 };
 
 /**
@@ -78,12 +80,13 @@ export const getIntegerFlag = (
  * @param {string} defaultValue
  * @returns {string} string flag value
  */
-export const getStringFlag = (
+export const getStringFlag = async (
   sessionManager: SessionManager,
   code: string,
   defaultValue?: string
-): string => {
-  return getFlag(sessionManager, code, defaultValue, 's').value as string;
+): Promise<string> => {
+  return (await getFlag(sessionManager, code, defaultValue, 's'))
+    .value as string;
 };
 
 /**
@@ -94,10 +97,11 @@ export const getStringFlag = (
  * @param {boolean} defaultValue
  * @returns {boolean} boolean flag value
  */
-export const getBooleanFlag = (
+export const getBooleanFlag = async (
   sessionManager: SessionManager,
   code: string,
   defaultValue?: boolean
-): boolean => {
-  return getFlag(sessionManager, code, defaultValue, 'b').value as boolean;
+): Promise<boolean> => {
+  return (await getFlag(sessionManager, code, defaultValue, 'b'))
+    .value as boolean;
 };

--- a/lib/sdk/utilities/random-string.ts
+++ b/lib/sdk/utilities/random-string.ts
@@ -1,4 +1,4 @@
-import {getRandomValues} from 'uncrypto';
+import { getRandomValues } from 'uncrypto';
 
 /**
  * Creates a random string of provided length.
@@ -8,7 +8,7 @@ import {getRandomValues} from 'uncrypto';
 export const generateRandomString = (length: number = 28): string => {
   const array = new Uint32Array(length);
   getRandomValues(array);
-  return Array.from(array, (dec) =>
-    ('0' + dec.toString(16)).slice(-2)
-  ).join('');
+  return Array.from(array, (dec) => ('0' + dec.toString(16)).slice(-2)).join(
+    ''
+  );
 };

--- a/lib/sdk/utilities/token-utils.ts
+++ b/lib/sdk/utilities/token-utils.ts
@@ -22,10 +22,10 @@ const getTokenPayload = (token: string): any => {
  * @param {string} idToken
  * @returns {void}
  */
-const commitUserToMemoryFromToken = (
+const commitUserToMemoryFromToken = async (
   sessionManager: SessionManager,
   idToken: string
-): void => {
+): Promise<void> => {
   const idTokenPayload = getTokenPayload(idToken);
   const user: UserType = {
     family_name: idTokenPayload.family_name,
@@ -35,7 +35,7 @@ const commitUserToMemoryFromToken = (
     id: idTokenPayload.sub,
   };
 
-  sessionManager.setSessionItem('user', user);
+  await sessionManager.setSessionItem('user', user);
 };
 
 /**
@@ -44,18 +44,18 @@ const commitUserToMemoryFromToken = (
  * @param {string} token
  * @param {TokenType} type
  */
-export const commitTokenToMemory = (
+export const commitTokenToMemory = async (
   sessionManager: SessionManager,
   token: string,
   type: TokenType
-): void => {
+): Promise<void> => {
   const tokenPayload = getTokenPayload(token);
-  sessionManager.setSessionItem(type, token);
+  await sessionManager.setSessionItem(type, token);
   if (type === 'access_token') {
-    sessionManager.setSessionItem('access_token_payload', tokenPayload);
+    await sessionManager.setSessionItem('access_token_payload', tokenPayload);
   } else if (type === 'id_token') {
-    sessionManager.setSessionItem('id_token_payload', tokenPayload);
-    commitUserToMemoryFromToken(sessionManager, token);
+    await sessionManager.setSessionItem('id_token_payload', tokenPayload);
+    await commitUserToMemoryFromToken(sessionManager, token);
   }
 };
 
@@ -65,13 +65,15 @@ export const commitTokenToMemory = (
  * @param {SessionManager} sessionManager
  * @param tokens
  */
-export const commitTokensToMemory = (
+export const commitTokensToMemory = async (
   sessionManager: SessionManager,
   tokens: TokenCollection
-): void => {
-  commitTokenToMemory(sessionManager, tokens.refresh_token, 'refresh_token');
-  commitTokenToMemory(sessionManager, tokens.access_token, 'access_token');
-  commitTokenToMemory(sessionManager, tokens.id_token, 'id_token');
+): Promise<void> => {
+  await Promise.all([
+    commitTokenToMemory(sessionManager, tokens.refresh_token, 'refresh_token'),
+    commitTokenToMemory(sessionManager, tokens.access_token, 'access_token'),
+    commitTokenToMemory(sessionManager, tokens.id_token, 'id_token'),
+  ]);
 };
 
 /**
@@ -80,10 +82,12 @@ export const commitTokensToMemory = (
  * @param {SessionManager} sessionManager
  * @returns {string | null}
  */
-export const getRefreshToken = (
+export const getRefreshToken = async (
   sessionManager: SessionManager
-): string | null => {
-  return sessionManager.getSessionItem('refresh_token') as string | null;
+): Promise<string | null> => {
+  return await (sessionManager.getSessionItem('refresh_token') as Promise<
+    string | null
+  >);
 };
 
 /**
@@ -92,10 +96,12 @@ export const getRefreshToken = (
  * @param {SessionManager} sessionManager
  * @returns {string | null}
  */
-export const getAccessToken = (
+export const getAccessToken = async (
   sessionManager: SessionManager
-): string | null => {
-  return sessionManager.getSessionItem('access_token') as string | null;
+): Promise<string | null> => {
+  return await (sessionManager.getSessionItem('access_token') as Promise<
+    string | null
+  >);
 };
 
 /**
@@ -104,10 +110,12 @@ export const getAccessToken = (
  * @param {SessionManager} sessionManager
  * @returns {string | null}
  */
-export const getUserFromMemory = (
+export const getUserFromMemory = async (
   sessionManager: SessionManager
-): UserType | null => {
-  return sessionManager.getSessionItem('user') as UserType | null;
+): Promise<UserType | null> => {
+  return await (sessionManager.getSessionItem(
+    'user'
+  ) as Promise<UserType | null>);
 };
 
 /**
@@ -115,11 +123,11 @@ export const getUserFromMemory = (
  * @param {SessionManager} sessionManager
  * @param {UserType} user
  */
-export const commitUserToMemory = (
+export const commitUserToMemory = async (
   sessionManager: SessionManager,
   user: UserType
 ) => {
-  sessionManager.setSessionItem('user', user);
+  await sessionManager.setSessionItem('user', user);
 };
 
 /**


### PR DESCRIPTION
# Explain your changes

Discovered when implementing Nuxt module for Kinde that we need support for async session in order to integrate with Nitro/H3 session, which would be the most platform-native way to do it for Nuxt.

You may wish to refactor or rethink how I've done this, but it's a start.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
