### PR TITLE
fix: avoid forcing login

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ interface RegisterURLOptions {
 Notice that you are able to override the `state` parameter in `RegisterURLOptions`,
 if not provided then the SDK will assign a random string to this value, this
 applies to the `login` method discussed below as well. In addition it must be 
-noted that interally this method will ensure the resulting registration URL has
+noted that internally this method will ensure the resulting registration URL has
 the `start_page` query parameter to `'registration'`.
 
 ### `login`
@@ -655,8 +655,6 @@ interface LoginURLOptions {
   state?: string;
 }
 ```
-In addition it must be noted that interally this method will ensure that the
-resulting login URL has the `start_page` query parameter to `'login'`.
 
 ### `createOrg`
 This method will return a registration URL, with the `is_create_org` parameter
@@ -677,7 +675,7 @@ interface CreateOrgURLOptions {
   state?: string;
 }
 ```
-In addition it must be noted that as in the `registration` method above interally 
+In addition it must be noted that as in the `registration` method above internally 
 this method will also set the `start_page` query parameter to `'registration'`.
 in the resulting URL.
 

--- a/lib/sdk/clients/browser/authcode-with-pkce.ts
+++ b/lib/sdk/clients/browser/authcode-with-pkce.ts
@@ -29,8 +29,7 @@ const createAuthCodeWithPKCEClient = (options: PKCEClientOptions) => {
    */
   const login = async (options?: LoginURLOptions): Promise<URL> => {
     return await client.createAuthorizationURL(sessionManager, {
-      ...options,
-      start_page: 'login',
+      ...options
     });
   };
 

--- a/lib/sdk/clients/server/authorization-code.ts
+++ b/lib/sdk/clients/server/authorization-code.ts
@@ -30,8 +30,7 @@ const createAuthorizationCodeClient = (
     options?: LoginURLOptions
   ): Promise<URL> => {
     return await client.createAuthorizationURL(sessionManager, {
-      ...options,
-      start_page: 'login',
+      ...options
     });
   };
 


### PR DESCRIPTION
# Explain your changes

Passing `start_page=login` will force a login even if logged in.  Making the default behaviour not pass this parameter so they will just flow back if already logged in.  We'll likey add an option to get this force login behaviour.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
