### PR TITLE
fix: don't store the decoded payload and decode when needed

### DIFF
--- a/lib/__tests__/sdk/utilities/feature-flags.spec.ts
+++ b/lib/__tests__/sdk/utilities/feature-flags.spec.ts
@@ -12,10 +12,6 @@ describe('feature-flags', () => {
 
   beforeEach(async () => {
     mockAccessToken = mocks.getMockAccessToken();
-    await sessionManager.setSessionItem(
-      'access_token_payload',
-      mockAccessToken.payload
-    );
     await sessionManager.setSessionItem('access_token', mockAccessToken.token);
   });
 

--- a/lib/__tests__/sdk/utilities/token-claims.spec.ts
+++ b/lib/__tests__/sdk/utilities/token-claims.spec.ts
@@ -17,14 +17,6 @@ describe('token-claims', () => {
   beforeEach(async () => {
     mockAccessToken = mocks.getMockAccessToken();
     mockIdToken = mocks.getMockIdToken();
-    await sessionManager.setSessionItem(
-      'access_token_payload',
-      mockAccessToken.payload
-    );
-    await sessionManager.setSessionItem(
-      'id_token_payload',
-      mockIdToken.payload
-    );
     await sessionManager.setSessionItem('access_token', mockAccessToken.token);
     await sessionManager.setSessionItem('id_token', mockIdToken.token);
   });
@@ -38,7 +30,7 @@ describe('token-claims', () => {
       Object.keys(mockAccessToken.payload).forEach(async (name: string) => {
         const claimValue = await getClaimValue(sessionManager, name);
         const tokenPayload = mockAccessToken.payload as Record<string, unknown>;
-        expect(claimValue).toBe(tokenPayload[name]);
+        expect(claimValue).toStrictEqual(tokenPayload[name]);
       });
     });
 

--- a/lib/sdk/utilities/token-claims.ts
+++ b/lib/sdk/utilities/token-claims.ts
@@ -1,6 +1,7 @@
 import { type SessionManager } from '../session-managers/index.js';
 import { isTokenExpired } from './token-utils.js';
 import { type ClaimTokenType } from './types.js';
+import { jwtDecode } from 'jwt-decode';
 
 /**
  * Method extracts the provided claim from the provided token type in the
@@ -15,9 +16,10 @@ export const getClaimValue = async (
   claim: string,
   type: ClaimTokenType = 'access_token'
 ): Promise<unknown | null> => {
-  const tokenPayload = (await sessionManager.getSessionItem(
-    `${type}_payload`
-  )) as Record<string, unknown>;
+  const token = (await sessionManager.getSessionItem(
+    `${type}`
+  )) as string;
+  const tokenPayload: Record<string, unknown> = jwtDecode(token);
   return tokenPayload[claim] ?? null;
 };
 

--- a/lib/sdk/utilities/token-utils.ts
+++ b/lib/sdk/utilities/token-utils.ts
@@ -38,12 +38,7 @@ export const commitTokenToMemory = async (
   type: TokenType
 ): Promise<void> => {
   await sessionManager.setSessionItem(type, token);
-  if (type === 'access_token') {
-    const tokenPayload = jwtDecode(token);
-    await sessionManager.setSessionItem('access_token_payload', tokenPayload);
-  } else if (type === 'id_token') {
-    const tokenPayload = jwtDecode(token);
-    await sessionManager.setSessionItem('id_token_payload', tokenPayload);
+  if (type === 'id_token') {
     await commitUserToMemoryFromToken(sessionManager, token);
   }
 };


### PR DESCRIPTION
# Explain your changes

While looking to add permissions, roles and feature flags support to the [nuxt module](https://github.com/nuxt-modules/kinde) I ran into an issue where the decoded payload was never stored and when trying to access the the permissions it was throwing the exception `Cannot read properties of undefined (reading 'permissions')`

If I manually added the decoded payload to the storage it was all ok.  

I opened a discussion with @DaveOrDead and it was suggested that a change could be made to not store the decoded token and just decode when needed.

This PR implements this change.  

All tests have been updated and pass.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
