### PR TITLE
Dynamic key for state cookie

### DIFF
--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -102,7 +102,7 @@ export class AuthorizationCode extends AuthCodeAbstract {
     try {
       return await this.fetchTokensFor(sessionManager, body);
     } finally {
-      // TODO: clean up all cookies with the prefix ${stateKey}
+      /* TODO: clean up all cookies with the prefix ${stateKey} */
       await sessionManager.removeSessionItem(`${stateKey}.${state}`);
     }
   }

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -102,6 +102,7 @@ export class AuthorizationCode extends AuthCodeAbstract {
     try {
       return await this.fetchTokensFor(sessionManager, body);
     } finally {
+      // TODO: clean up all cookies with the prefix ${stateKey}
       await sessionManager.removeSessionItem(`${stateKey}.${state}`);
     }
   }

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -38,7 +38,7 @@ export class AuthorizationCode extends AuthCodeAbstract {
   ): Promise<URL> {
     this.state = options.state ?? utilities.generateRandomString();
     await sessionManager.setSessionItem(
-      AuthorizationCode.STATE_KEY,
+      `${AuthorizationCode.STATE_KEY}.${this.state}`,
       this.state
     );
     const authURL = new URL(this.authorizationEndpoint);
@@ -84,10 +84,10 @@ export class AuthorizationCode extends AuthCodeAbstract {
   ): Promise<OAuth2CodeExchangeResponse> {
     const [code, state] = this.getCallbackURLParams(callbackURL);
     const stateKey = AuthorizationCode.STATE_KEY;
-    const storedState = (await sessionManager.getSessionItem(stateKey)) as
+    const storedState = (await sessionManager.getSessionItem(`${stateKey}.${state}`)) as
       | string
       | null;
-    if (!storedState || storedState !== state) {
+    if (!storedState) {
       throw new Error('Authentication flow state not found');
     }
 
@@ -102,7 +102,7 @@ export class AuthorizationCode extends AuthCodeAbstract {
     try {
       return await this.fetchTokensFor(sessionManager, body);
     } finally {
-      await sessionManager.removeSessionItem(stateKey);
+      await sessionManager.removeSessionItem(`${stateKey}.${state}`);
     }
   }
 


### PR DESCRIPTION
# Explain your changes

Starting the auth flow in multiple tabs will result in previous state cookies being wiped due to the key being the same.

Making the key dynamic will prevent this.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
