### PR TITLE
Use state if existing in session

### DIFF
--- a/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
@@ -96,6 +96,19 @@ describe('AuthorizationCode', () => {
       const state = searchParams.get('state');
       expect(state).toBe(expectedState);
     });
+
+    it('uses same state to generate authorization URL if existing in session', async () => {
+      const client = new AuthorizationCode(clientConfig, clientSecret);
+      const authURL = await client.createAuthorizationURL(sessionManager);
+      const searchParams = new URLSearchParams(authURL.search);
+      const firstState = searchParams.get('state');
+
+      const authURL2 = await client.createAuthorizationURL(sessionManager);
+      const searchParams2 = new URLSearchParams(authURL2.search);
+      const secondState = searchParams2.get('state');
+
+      expect(firstState).toBe(secondState);
+    });
   });
 
   describe('handleRedirectFromAuthDomain()', () => {

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -36,7 +36,12 @@ export class AuthorizationCode extends AuthCodeAbstract {
     sessionManager: SessionManager,
     options: AuthURLOptions = {}
   ): Promise<URL> {
-    this.state = options.state ?? utilities.generateRandomString();
+    this.state =
+      options.state ??
+      ((await sessionManager.getSessionItem(
+        AuthorizationCode.STATE_KEY
+      )) as string) ??
+      utilities.generateRandomString();
     await sessionManager.setSessionItem(AuthorizationCode.STATE_KEY, this.state);
     const authURL = new URL(this.authorizationEndpoint);
     const authParams = this.generateAuthURLParams(options);


### PR DESCRIPTION
# Explain your changes

When generating multiple links, the state of earlier links are overridden so do not successfully complete login on callback.  Specifically, where login is started in multiple tabs, only the last one can be used successfully to login.  These changes reuse state until successful login, so any of the tabs can be used to login.

Note: After login, the remaining tabs will still not be able to be used for login.  The `state` can still be passed in if a new state is preferred on every call.

Alternative solution to: https://github.com/kinde-oss/kinde-typescript-sdk/pull/40

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
