### PR TITLE
feat: validate client secrets

### DIFF
--- a/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
@@ -13,7 +13,7 @@ import { generateRandomString } from '../../../sdk/utilities';
 
 describe('AuthorizationCode', () => {
   const { sessionManager } = mocks;
-  const clientSecret = generateRandomString(25);
+  const clientSecret = generateRandomString(50);
   const clientConfig: AuthorizationCodeOptions = {
     authDomain: 'https://local-testing@kinde.com',
     redirectURL: 'https://app-domain.com',

--- a/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
@@ -9,10 +9,11 @@ import {
 } from '../../../sdk/oauth2-flows';
 
 import { KindeSDKError, KindeSDKErrorCode } from '../../../sdk/exceptions';
+import { generateRandomString } from '../../../sdk/utilities';
 
 describe('AuthorizationCode', () => {
   const { sessionManager } = mocks;
-  const clientSecret = 'client-secret' as const;
+  const clientSecret = generateRandomString(50);
   const clientConfig: AuthorizationCodeOptions = {
     authDomain: 'https://local-testing@kinde.com',
     redirectURL: 'https://app-domain.com',

--- a/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/AuthorizationCode.spec.ts
@@ -13,7 +13,7 @@ import { generateRandomString } from '../../../sdk/utilities';
 
 describe('AuthorizationCode', () => {
   const { sessionManager } = mocks;
-  const clientSecret = generateRandomString(50);
+  const clientSecret = generateRandomString(25);
   const clientConfig: AuthorizationCodeOptions = {
     authDomain: 'https://local-testing@kinde.com',
     redirectURL: 'https://app-domain.com',

--- a/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
@@ -8,7 +8,7 @@ describe('ClientCredentials', () => {
   const clientConfig: ClientCredentialsOptions = {
     authDomain: 'https://local-testing@kinde.com',
     logoutRedirectURL: 'http://app-domain.com',
-    clientSecret: generateRandomString(25),
+    clientSecret: generateRandomString(50),
     clientId: 'client-id',
   };
 

--- a/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
@@ -8,7 +8,7 @@ describe('ClientCredentials', () => {
   const clientConfig: ClientCredentialsOptions = {
     authDomain: 'https://local-testing@kinde.com',
     logoutRedirectURL: 'http://app-domain.com',
-    clientSecret: generateRandomString(50),
+    clientSecret: generateRandomString(25),
     clientId: 'client-id',
   };
 

--- a/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
@@ -1,6 +1,6 @@
 import { ClientCredentials } from '../../../sdk/oauth2-flows/ClientCredentials';
 import { type ClientCredentialsOptions } from '../../../sdk/oauth2-flows/types';
-import { commitTokenToMemory } from '../../../sdk/utilities';
+import { commitTokenToMemory, generateRandomString } from '../../../sdk/utilities';
 import { getSDKHeader } from '../../../sdk/version';
 import * as mocks from '../../mocks';
 
@@ -8,7 +8,7 @@ describe('ClientCredentials', () => {
   const clientConfig: ClientCredentialsOptions = {
     authDomain: 'https://local-testing@kinde.com',
     logoutRedirectURL: 'http://app-domain.com',
-    clientSecret: 'client-secret',
+    clientSecret: generateRandomString(50),
     clientId: 'client-id',
   };
 

--- a/lib/__tests__/sdk/utilities/validate-client-secret.spec.ts
+++ b/lib/__tests__/sdk/utilities/validate-client-secret.spec.ts
@@ -1,0 +1,15 @@
+import { validateClientSecret } from '../../../sdk/utilities';
+
+describe('validateClientSecret', () => {
+  it('should return true for valid secrets', () => {
+    const validSecret = 'HlibujiUbwbMXofgh12F7Abur5JM5FZCDZHJQenpwEO7UCsNnqzm';
+    const result = validateClientSecret(validSecret);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for invalid secrets', () => {
+    const invalidSecret = '123';
+    const result = validateClientSecret(invalidSecret);
+    expect(result).toBe(false);
+  });
+});

--- a/lib/sdk/index.ts
+++ b/lib/sdk/index.ts
@@ -3,3 +3,4 @@ export * from './oauth2-flows/types.js';
 export * from './utilities/types.js';
 export * from './clients/index.js';
 export * from './exceptions.js';
+export * from './utilities/validate-client-secret.js';

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -60,6 +60,11 @@ export class AuthorizationCode extends AuthCodeAbstract {
     sessionManager: SessionManager
   ): Promise<OAuth2CodeExchangeResponse> {
     const refreshToken = await utilities.getRefreshToken(sessionManager);
+
+    if (!utilities.validateClientSecret(this.clientSecret)) {
+      throw new Error(`Invalid client secret ${this.clientSecret}`);
+    }
+
     const body = new URLSearchParams({
       grant_type: 'refresh_token',
       client_id: this.config.clientId,
@@ -99,6 +104,10 @@ export class AuthorizationCode extends AuthCodeAbstract {
       throw new Error(
         `Authentication flow: State mismatch. Received: ${state} | Expected: ${storedState}`
       );
+    }
+
+    if (!utilities.validateClientSecret(this.clientSecret)) {
+      throw new Error(`Invalid client secret ${this.clientSecret}`);
     }
 
     const body = new URLSearchParams({

--- a/lib/sdk/oauth2-flows/ClientCredentials.ts
+++ b/lib/sdk/oauth2-flows/ClientCredentials.ts
@@ -110,6 +110,10 @@ export class ClientCredentials {
     let scope = this.config.scope ?? ClientCredentials.DEFAULT_TOKEN_SCOPES
     scope = scope.split(' ').includes('openid') ? scope : `${scope} openid`;
 
+    if (!utilities.validateClientSecret(this.config.clientSecret)) {
+      throw new Error(`Invalid client secret ${this.config.clientSecret}`);
+    }
+
     const searchParams = new URLSearchParams({
       grant_type: 'client_credentials',
       scope,

--- a/lib/sdk/utilities/index.ts
+++ b/lib/sdk/utilities/index.ts
@@ -8,3 +8,4 @@ export * from './random-string.js';
 export * from './token-claims.js';
 export * from './token-utils.js';
 export * from './types.js';
+export * from './validate-client-secret.js';

--- a/lib/sdk/utilities/validate-client-secret.ts
+++ b/lib/sdk/utilities/validate-client-secret.ts
@@ -1,0 +1,8 @@
+/**
+ * Validates that the supplied client secret is in the correct format.
+ * @param {string} secret
+ * @returns {boolean} 
+ */
+export const validateClientSecret = (secret: string): boolean => {
+  return !!secret.match('[a-zA-Z0-9]{50}')?.length
+};

--- a/lib/sdk/utilities/validate-client-secret.ts
+++ b/lib/sdk/utilities/validate-client-secret.ts
@@ -4,5 +4,5 @@
  * @returns {boolean} 
  */
 export const validateClientSecret = (secret: string): boolean => {
-  return !!secret.match('^[a-zA-Z0-9]{40,50}$')?.length
+  return !!secret.match('^[a-zA-Z0-9]{40,60}$')?.length
 };

--- a/lib/sdk/utilities/validate-client-secret.ts
+++ b/lib/sdk/utilities/validate-client-secret.ts
@@ -4,5 +4,5 @@
  * @returns {boolean} 
  */
 export const validateClientSecret = (secret: string): boolean => {
-  return !!secret.match('[a-zA-Z0-9]{50}')?.length
+  return !!secret.match('^[a-zA-Z0-9]{40,50}$')?.length
 };


### PR DESCRIPTION
# Explain your changes

- This exposes a method to validate the client secret which can be used by other SDKs
- Validates the secret before using and throws exception is not valid

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced security measures for OAuth2 flows by validating client secrets before token exchanges and requests.
- **Tests**
	- Added a comprehensive test suite for the new client secret validation functionality.
- **Refactor**
	- Updated the generation of `clientSecret` to use randomly generated strings, improving security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->