### PR TITLE
fix: generateRandomString returning double length

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For details on integrating this SDK into your project, head over to the [Kinde d
 
 ## Publishing
 
-The core team handles publishing.
+The Kinde core team handles publishing.
 
 ## Contributing
 

--- a/lib/__tests__/sdk/utilities/generateRandomString.spec.ts
+++ b/lib/__tests__/sdk/utilities/generateRandomString.spec.ts
@@ -1,0 +1,13 @@
+import { generateRandomString } from '../../../sdk/utilities';
+
+describe('validateClientSecret', () => {
+  it('should return true for valid secrets', () => {
+    const result = generateRandomString(25);
+    expect(result.length).toBe(25);
+  });
+
+  it('should return false for invalid secrets', () => {
+    const result = generateRandomString(50);
+    expect(result.length).toBe(50);
+  });
+});

--- a/lib/__tests__/sdk/utilities/generateRandomString.spec.ts
+++ b/lib/__tests__/sdk/utilities/generateRandomString.spec.ts
@@ -6,6 +6,12 @@ describe('validateClientSecret', () => {
     expect(result.length).toBe(25);
   });
 
+
+  it('should return false for invalid secrets - odd length', () => {
+    const result = generateRandomString(47);
+    expect(result.length).toBe(47);
+  });
+
   it('should return false for invalid secrets', () => {
     const result = generateRandomString(50);
     expect(result.length).toBe(50);

--- a/lib/sdk/utilities/random-string.ts
+++ b/lib/sdk/utilities/random-string.ts
@@ -6,7 +6,13 @@ import { getRandomValues } from 'uncrypto';
  * @returns {string} required secret
  */
 export const generateRandomString = (length: number = 28): string => {
-  const array = new Uint32Array(length);
+  const bytesNeeded = Math.ceil(length / 2);
+  const array = new Uint32Array(bytesNeeded);
   getRandomValues(array);
-  return Array.from(array, (dec) => ('0' + dec.toString(16)).slice(-2)).join('').slice(0, length);
+  let result = Array.from(array, (dec) => ('0' + dec.toString(16)).slice(-2)).join('');
+  if (length % 2 !== 0) {
+    // If the requested length is odd, remove the last character to adjust the length
+    result = result.slice(0, -1);
+  }
+  return result;
 };

--- a/lib/sdk/utilities/random-string.ts
+++ b/lib/sdk/utilities/random-string.ts
@@ -8,5 +8,5 @@ import { getRandomValues } from 'uncrypto';
 export const generateRandomString = (length: number = 28): string => {
   const array = new Uint32Array(length);
   getRandomValues(array);
-  return Array.from(array, (dec) => ('0' + dec.toString(16)).slice(-2)).join('');
+  return Array.from(array, (dec) => ('0' + dec.toString(16)).slice(-2)).join('').slice(0, length);
 };


### PR DESCRIPTION
# Explain your changes

`generateRandomString` was returning strings twice the requested length

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Clarified the role of the "Kinde core team" in publishing responsibilities.

- **New Features**
	- Improved `generateRandomString` function to match output length with the specified input length.

- **Tests**
	- Added tests for the `generateRandomString` function in the SDK utilities module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->