### PR TITLE
bug: exclude openid from client credentials flow

### DIFF
--- a/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
@@ -25,7 +25,6 @@ describe('ClientCredentials', () => {
 
     const body = new URLSearchParams({
       grant_type: 'client_credentials',
-      scope: ClientCredentials.DEFAULT_TOKEN_SCOPES,
       client_id: clientConfig.clientId,
       client_secret: clientConfig.clientSecret,
     });
@@ -115,7 +114,7 @@ describe('ClientCredentials', () => {
         json: () => ({ access_token: mockAccessToken }),
       });
 
-      const expectedScope = 'test-scope openid';
+      const expectedScope = 'test-scope';
       const expectedAudience = 'test-audience';
       const client = new ClientCredentials({
         ...clientConfig,

--- a/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
+++ b/lib/__tests__/sdk/oauth2-flows/ClientCredentials.spec.ts
@@ -124,9 +124,9 @@ describe('ClientCredentials', () => {
 
       const expectedBody = new URLSearchParams({
         grant_type: 'client_credentials',
-        scope: expectedScope,
         client_id: clientConfig.clientId,
         client_secret: clientConfig.clientSecret,
+        scope: expectedScope,
         audience: expectedAudience,
       });
 

--- a/lib/sdk/oauth2-flows/ClientCredentials.ts
+++ b/lib/sdk/oauth2-flows/ClientCredentials.ts
@@ -13,7 +13,6 @@ import type {
  * @class ClientCredentials
  */
 export class ClientCredentials {
-  public static DEFAULT_TOKEN_SCOPES: string = 'openid profile email offline';
   public readonly logoutEndpoint: string;
   public readonly tokenEndpoint: string;
 
@@ -107,19 +106,19 @@ export class ClientCredentials {
    * @returns {URLSearchParams}
    */
   private generateTokenURLParams(): URLSearchParams {
-    let scope = this.config.scope ?? ClientCredentials.DEFAULT_TOKEN_SCOPES
-    scope = scope.split(' ').includes('openid') ? scope : `${scope} openid`;
-
     if (!utilities.validateClientSecret(this.config.clientSecret)) {
       throw new Error(`Invalid client secret ${this.config.clientSecret}`);
     }
 
     const searchParams = new URLSearchParams({
       grant_type: 'client_credentials',
-      scope,
       client_id: this.config.clientId,
       client_secret: this.config.clientSecret,
     });
+
+    if (this.config.scope !== undefined) {
+      searchParams.append('scope', this.config.scope);
+    }
 
     if (this.config.audience) {
       const audienceArray = Array.isArray(this.config.audience) ? this.config.audience : [this.config.audience];


### PR DESCRIPTION
# Explain your changes

Client credentials flow isn't part of OpenID Connect so the `openid` scope is not relevant, `scope` is actually also optional and the defaults likely do not make sense with no user.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of scope properties in OAuth2 client credentials flow.
- **Tests**
	- Updated tests to reflect changes in scope handling for OAuth2 flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->