### PR TITLE
fix: logout redirect is not required

### DIFF
--- a/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
@@ -32,7 +32,7 @@ export abstract class AuthCodeAbstract {
 
   constructor(protected readonly config: AuthorizationCodeOptions) {
     const { authDomain, logoutRedirectURL } = config;
-    this.logoutEndpoint = `${authDomain}/logout?redirect=${logoutRedirectURL}`;
+    this.logoutEndpoint = `${authDomain}/logout?redirect=${logoutRedirectURL ?? ''}`;
     this.userProfileEndpoint = `${authDomain}/oauth2/v2/user_profile`;
     this.authorizationEndpoint = `${authDomain}/oauth2/auth`;
     this.tokenEndpoint = `${authDomain}/oauth2/token`;

--- a/lib/sdk/oauth2-flows/ClientCredentials.ts
+++ b/lib/sdk/oauth2-flows/ClientCredentials.ts
@@ -21,7 +21,7 @@ export class ClientCredentials {
 
   constructor(private readonly config: ClientCredentialsOptions) {
     const { authDomain, logoutRedirectURL } = config;
-    this.logoutEndpoint = `${authDomain}/logout?redirect=${logoutRedirectURL}`;
+    this.logoutEndpoint = `${authDomain}/logout?redirect=${logoutRedirectURL ?? ''}`;
     this.tokenEndpoint = `${authDomain}/oauth2/token`;
     this.config = config;
     const keyProvider = async () => {

--- a/lib/sdk/oauth2-flows/types.ts
+++ b/lib/sdk/oauth2-flows/types.ts
@@ -32,7 +32,7 @@ export interface OAuth2CCTokenResponse {
 
 export interface OAuth2FlowOptions {
   clientId: string;
-  logoutRedirectURL: string;
+  logoutRedirectURL?: string;
   authDomain: string;
   audience?: string | string[];
   scope?: string;


### PR DESCRIPTION
# Explain your changes

Log out redirect is not really required - the user will be directed to a generic log out screen if not provided.  It also doesn't necessarily make sense for client credential flows and I see in the Svelte SDK it seems to use type assertions to avoid providing it: https://github.com/kinde-oss/kinde-sveltekit-sdk/blob/dbae249abe2e0c75913826b66a397afc25b6f548/src/lib/KindeSDK.ts#L19C3-L19C24

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved handling of logout redirection URLs in authentication flows to ensure more robust and error-free user sign-out experiences.
- **Refactor**
	- Updated the `AuthCodeAbstract` and `ClientCredentials` classes to handle `logoutRedirectURL` more efficiently.
	- Made the `logoutRedirectURL` property optional in the `OAuth2FlowOptions` interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->