### PR TITLE
bug: prevent expiry exception when reading id token claims

### DIFF
--- a/lib/sdk/utilities/token-claims.ts
+++ b/lib/sdk/utilities/token-claims.ts
@@ -18,7 +18,7 @@ export const getClaimValue = async (
 ): Promise<unknown | null> => {
   const token = (await sessionManager.getSessionItem(`${type}`)) as string;
   const key = await validationDetails.keyProvider();
-  const decodedToken = await jwtVerify(token, key);
+  const decodedToken = await jwtVerify(token, key, type === 'id_token' ? { currentDate: new Date(0) } : {});
   const tokenPayload: Record<string, unknown> = decodedToken.payload;
   return tokenPayload[claim] ?? null;
 };


### PR DESCRIPTION
# Explain your changes

Since changes in https://github.com/kinde-oss/kinde-typescript-sdk/pull/46 there is potential to exception when the ID token has expired when we previously did not.  It is not necessarily wrong to read from an expired ID token as long as it was valid when the session started.  A future feature would be to query for fresh data when expired.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
