### PR TITLE
feat: allow the ability to refreshTokens without also committing them to the session

### DIFF
--- a/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
@@ -88,7 +88,7 @@ export abstract class AuthCodeAbstract {
    * Abstract method will implement logic in child classes for refreshing access token
    * using refresh token available in current session.
    * @param {SessionManager} sessionManager
-   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refresh tokens to the session. Defaults to true.
+   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refreshed tokens to the session. Defaults to true.
    * @returns {Promise<OAuth2CodeExchangeResponse>}
    */
   public abstract refreshTokens(

--- a/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
@@ -88,10 +88,12 @@ export abstract class AuthCodeAbstract {
    * Abstract method will implement logic in child classes for refreshing access token
    * using refresh token available in current session.
    * @param {SessionManager} sessionManager
+   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refresh tokens to the session. Defaults to true.
    * @returns {Promise<OAuth2CodeExchangeResponse>}
    */
   public abstract refreshTokens(
-    sessionManager: SessionManager
+    sessionManager: SessionManager,
+    commitToSession?: boolean
   ): Promise<OAuth2CodeExchangeResponse>;
 
   /**

--- a/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
@@ -69,7 +69,7 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
    * `AuthCodeAbstract` parent class, see corresponding comment in parent class for
    * further explanation.
    * @param {SessionManager} sessionManager
-   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refresh tokens to the session. Defaults to true.
+   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refreshed tokens to the session. Defaults to true.
    * @returns {Promise<OAuth2CodeExchangeResponse>}
    */
   public async refreshTokens(

--- a/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
@@ -69,10 +69,12 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
    * `AuthCodeAbstract` parent class, see corresponding comment in parent class for
    * further explanation.
    * @param {SessionManager} sessionManager
+   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refresh tokens to the session. Defaults to true.
    * @returns {Promise<OAuth2CodeExchangeResponse>}
    */
   public async refreshTokens(
-    sessionManager: SessionManager
+    sessionManager: SessionManager,
+    commitToSession: boolean = true
   ): Promise<OAuth2CodeExchangeResponse> {
     const refreshToken = await utilities.getRefreshToken(sessionManager);
     const body = new URLSearchParams({
@@ -82,11 +84,13 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
     });
 
     const tokens = await this.fetchTokensFor(sessionManager, body, true);
-    await utilities.commitTokensToSession(
-      sessionManager,
-      tokens,
-      this.tokenValidationDetails
-    );
+    if (commitToSession) {
+      await utilities.commitTokensToSession(
+        sessionManager,
+        tokens,
+        this.tokenValidationDetails
+      );
+    }
     return tokens;
   }
 

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -54,10 +54,12 @@ export class AuthorizationCode extends AuthCodeAbstract {
    * `AuthCodeAbstract` parent class, see corresponding comment in parent class for
    * further explanation.
    * @param {SessionManager} sessionManager
+   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refresh tokens to the session. Defaults to true.
    * @returns {Promise<OAuth2CodeExchangeResponse>}
    */
   public async refreshTokens(
-    sessionManager: SessionManager
+    sessionManager: SessionManager,
+    commitToSession: boolean = true
   ): Promise<OAuth2CodeExchangeResponse> {
     const refreshToken = await utilities.getRefreshToken(sessionManager);
 
@@ -73,11 +75,13 @@ export class AuthorizationCode extends AuthCodeAbstract {
     });
 
     const tokens = await this.fetchTokensFor(sessionManager, body);
-    await utilities.commitTokensToSession(
-      sessionManager,
-      tokens,
-      this.tokenValidationDetails
-    );
+    if (commitToSession) {
+      await utilities.commitTokensToSession(
+        sessionManager,
+        tokens,
+        this.tokenValidationDetails
+      );
+    }
     return tokens;
   }
 

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -54,7 +54,7 @@ export class AuthorizationCode extends AuthCodeAbstract {
    * `AuthCodeAbstract` parent class, see corresponding comment in parent class for
    * further explanation.
    * @param {SessionManager} sessionManager
-   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refresh tokens to the session. Defaults to true.
+   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refreshed tokens to the session. Defaults to true.
    * @returns {Promise<OAuth2CodeExchangeResponse>}
    */
   public async refreshTokens(


### PR DESCRIPTION
Change primarily aimed at changes in the Next SDK.

Introduces a new optional parameter to `AuthCodeAbstract.refreshTokens()` called `commitToSession`, which defaults to true in all implementations (`AuthCodeWithPKCE`, `AuthorizationCode`). 

By defaulting to true in this additional parameter we introduce no breaking changes, but allow consumers to call `refreshTokens(session, false)` to retrieve the refresh response _without_ committing the new tokens to the session.