### PR TITLE
fix: pull optional parameter up to refreshTokens abstraction

### DIFF
--- a/lib/sdk/clients/server/authorization-code.ts
+++ b/lib/sdk/clients/server/authorization-code.ts
@@ -142,12 +142,14 @@ const createAuthorizationCodeClient = (
    * Method makes user of the `refreshTokens` method of the `AuthCodeAbstract` client
    * to use the refresh token to get new tokens
    * @param {SessionManager} sessionManager
+   * @param {boolean} [commitToSession=true] - Optional parameter, determines whether to commit the refreshed tokens to the session. Defaults to true.
    * @returns {Promise<OAuth2CodeExchangeResponse>}
    */
   const refreshTokens = async (
-    sessionManager: SessionManager
+    sessionManager: SessionManager,
+    commitToSession: boolean = true
   ): Promise<OAuth2CodeExchangeResponse> => {
-    return await client.refreshTokens(sessionManager);
+    return await client.refreshTokens(sessionManager, commitToSession);
   };
 
   /**


### PR DESCRIPTION
Extension of #67 

Clients were given the ability to optionally commit the session, but the wrapper for it if retrieving a client via the `createAuthorizationCodeClient` helper method was missed. This resolves that.