### PR TITLE
fix for auth url params

### DIFF
--- a/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
@@ -292,8 +292,10 @@ export abstract class AuthCodeAbstract {
         lang,
         login_hint: loginHint,
         connection_id: connectionId,
+        state,
         ...rest
       } = options.authUrlParams;
+      
       searchParamsObject = { ...rest, ...searchParamsObject };
 
       if (lang) {

--- a/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
@@ -295,7 +295,7 @@ export abstract class AuthCodeAbstract {
         state,
         ...rest
       } = options.authUrlParams;
-      
+
       searchParamsObject = { ...rest, ...searchParamsObject };
 
       if (lang) {

--- a/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
@@ -47,7 +47,11 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
     this.codeChallenge = challenge;
     this.codeVerifier = verifier;
 
-    this.state = options.state ?? utilities.generateRandomString();
+    // Check if state is provided in authUrlParams
+    const providedState = options.state || options.authUrlParams?.state;
+    
+    this.state = providedState ?? utilities.generateRandomString();
+    
     const setItem = isBrowserEnvironment()
       ? (sessionManager as unknown as BrowserSessionManager).setSessionItemBrowser
       : sessionManager.setSessionItem;

--- a/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
@@ -47,8 +47,7 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
     this.codeChallenge = challenge;
     this.codeVerifier = verifier;
 
-    // Check if state is provided in authUrlParams
-    const providedState = options.state || options.authUrlParams?.state;
+    const providedState = options.state ?? options.authUrlParams?.state;
     
     this.state = providedState ?? utilities.generateRandomString();
     

--- a/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
@@ -48,9 +48,9 @@ export class AuthCodeWithPKCE extends AuthCodeAbstract {
     this.codeVerifier = verifier;
 
     const providedState = options.state ?? options.authUrlParams?.state;
-    
+
     this.state = providedState ?? utilities.generateRandomString();
-    
+
     const setItem = isBrowserEnvironment()
       ? (sessionManager as unknown as BrowserSessionManager).setSessionItemBrowser
       : sessionManager.setSessionItem;

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -36,12 +36,15 @@ export class AuthorizationCode extends AuthCodeAbstract {
     sessionManager: SessionManager,
     options: AuthURLOptions = {}
   ): Promise<URL> {
+    const providedState = options.state || options.authUrlParams?.state;
+    
     this.state =
-      options.state ??
+      providedState ??
       ((await sessionManager.getSessionItem(
         AuthorizationCode.STATE_KEY
       )) as string) ??
       utilities.generateRandomString();
+    
     await sessionManager.setSessionItem(AuthorizationCode.STATE_KEY, this.state);
     const authURL = new URL(this.authorizationEndpoint);
     const authParams = this.generateAuthURLParams(options);

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -36,7 +36,7 @@ export class AuthorizationCode extends AuthCodeAbstract {
     sessionManager: SessionManager,
     options: AuthURLOptions = {}
   ): Promise<URL> {
-    const providedState = options.state || options.authUrlParams?.state;
+    const providedState = options.state ?? options.authUrlParams?.state;
     
     this.state =
       providedState ??

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -37,14 +37,14 @@ export class AuthorizationCode extends AuthCodeAbstract {
     options: AuthURLOptions = {}
   ): Promise<URL> {
     const providedState = options.state ?? options.authUrlParams?.state;
-    
+
     this.state =
       providedState ??
       ((await sessionManager.getSessionItem(
         AuthorizationCode.STATE_KEY
       )) as string) ??
       utilities.generateRandomString();
-    
+
     await sessionManager.setSessionItem(AuthorizationCode.STATE_KEY, this.state);
     const authURL = new URL(this.authorizationEndpoint);
     const authParams = this.generateAuthURLParams(options);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postbuild": "node sdk-version.js clean && ncp ./package-cjs.json ./dist-cjs/package.json && ncp ./package-esm.json ./dist/package.json",
     "prebuild": "node sdk-version.js && rimraf dist dist-cjs lib/models lib/apis",
     "lint": "eslint . && prettier . --check",
-    "lint:fix": "eslint --fix . && prettier . --check",
+    "lint:fix": "eslint --fix . && prettier . --write",
     "test": "jest --passWithNoTests",
     "lint-staged": "lint-staged",
     "husky": "husky install",


### PR DESCRIPTION
Fix: Prevent duplicate state parameters in OAuth2 authorization URLs

Problem
---------------------
Authorization URLs were generating duplicate state parameters when custom state was provided via authUrlParams.state, causing OAuth2 spec violations and potential authentication issues.

Example problematic URL:
------------------------------
https://domain.com/oauth2/auth?state=custom&...&state=custom&scope=openid

Root Cause
------------------

1. getBaseAuthURLParams() correctly added state parameter from this.state
2. generateAuthURLParams() incorrectly re-added the same state from authUrlParams.state
3. AuthorizationCode and AuthCodeWithPKCE only resolved state from options.state, ignoring authUrlParams.state

Solution
-------------------

1. AuthCodeAbstract.ts: Extract state separately during authUrlParams destructuring to prevent duplication
2. AuthorizationCode.ts: Add state resolution from both options.state and authUrlParams.state
3. AuthCodeWithPKCE.ts: Add state resolution from both options.state and authUrlParams.state