### PR TITLE
Add split-cookies utility functions and tests

### DIFF
--- a/lib/__tests__/sdk/utilities/split-cookies.spec.ts
+++ b/lib/__tests__/sdk/utilities/split-cookies.spec.ts
@@ -4,9 +4,26 @@ import {
   getSplitCookies,
   MAX_COOKIE_LENGTH,
 } from '../../../sdk/utilities';
+import { storageSettings } from '@kinde/js-utils';
 import { describe, it, expect } from 'vitest';
 
 describe('split-cookies utilities', () => {
+  it('reads default max cookie length from storageSettings', () => {
+    const originalMaxLength = storageSettings.maxLength;
+    storageSettings.maxLength = 4;
+
+    try {
+      const split = getSplitCookies('access_token', 'abcdefghij');
+      expect(split).toEqual([
+        { name: 'access_token', value: 'abcd' },
+        { name: 'access_token1', value: 'efgh' },
+        { name: 'access_token2', value: 'ij' },
+      ]);
+    } finally {
+      storageSettings.maxLength = originalMaxLength;
+    }
+  });
+
   it('splits a long value into multiple cookies and rejoins it', () => {
     const original = 'a'.repeat(MAX_COOKIE_LENGTH * 2 + 123);
     const split = getSplitCookies('access_token', original);

--- a/lib/__tests__/sdk/utilities/split-cookies.spec.ts
+++ b/lib/__tests__/sdk/utilities/split-cookies.spec.ts
@@ -1,13 +1,24 @@
 import {
   getJoinedSplitCookieValue,
+  getMaxCookieLength,
   getSplitCookieNamesToDelete,
   getSplitCookies,
-  MAX_COOKIE_LENGTH,
 } from '../../../sdk/utilities';
 import { storageSettings } from '@kinde/js-utils';
 import { describe, it, expect } from 'vitest';
 
 describe('split-cookies utilities', () => {
+  it('reads max cookie length via accessor from storageSettings', () => {
+    const originalMaxLength = storageSettings.maxLength;
+    storageSettings.maxLength = 7;
+
+    try {
+      expect(getMaxCookieLength()).toBe(7);
+    } finally {
+      storageSettings.maxLength = originalMaxLength;
+    }
+  });
+
   it('reads default max cookie length from storageSettings', () => {
     const originalMaxLength = storageSettings.maxLength;
     storageSettings.maxLength = 4;
@@ -25,7 +36,8 @@ describe('split-cookies utilities', () => {
   });
 
   it('splits a long value into multiple cookies and rejoins it', () => {
-    const original = 'a'.repeat(MAX_COOKIE_LENGTH * 2 + 123);
+    const maxCookieLength = getMaxCookieLength();
+    const original = 'a'.repeat(maxCookieLength * 2 + 123);
     const split = getSplitCookies('access_token', original);
 
     expect(split.length).toBe(3);

--- a/lib/__tests__/sdk/utilities/split-cookies.spec.ts
+++ b/lib/__tests__/sdk/utilities/split-cookies.spec.ts
@@ -30,6 +30,18 @@ describe('split-cookies utilities', () => {
     expect(getJoinedSplitCookieValue('access_token', cookies)).toBeUndefined();
   });
 
+  it('throws when maxCookieLength is not a positive integer', () => {
+    expect(() => getSplitCookies('access_token', 'value', 0)).toThrow(
+      'maxCookieLength must be a positive integer'
+    );
+    expect(() => getSplitCookies('access_token', 'value', -1)).toThrow(
+      'maxCookieLength must be a positive integer'
+    );
+    expect(() => getSplitCookies('access_token', 'value', 1.5)).toThrow(
+      'maxCookieLength must be a positive integer'
+    );
+  });
+
   it('lists all cookie chunks to delete via startsWith', () => {
     const names = [
       'access_token',

--- a/lib/__tests__/sdk/utilities/split-cookies.spec.ts
+++ b/lib/__tests__/sdk/utilities/split-cookies.spec.ts
@@ -1,0 +1,48 @@
+import {
+  getJoinedSplitCookieValue,
+  getSplitCookieNamesToDelete,
+  getSplitCookies,
+  MAX_COOKIE_LENGTH,
+} from '../../../sdk/utilities';
+import { describe, it, expect } from 'vitest';
+
+describe('split-cookies utilities', () => {
+  it('splits a long value into multiple cookies and rejoins it', () => {
+    const original = 'a'.repeat(MAX_COOKIE_LENGTH * 2 + 123);
+    const split = getSplitCookies('access_token', original);
+
+    expect(split.length).toBe(3);
+    expect(split[0].name).toBe('access_token');
+    expect(split[1].name).toBe('access_token1');
+    expect(split[2].name).toBe('access_token2');
+
+    const cookieRecord: Record<string, string> = Object.fromEntries(
+      split.map((c) => [c.name, c.value])
+    );
+    const joined = getJoinedSplitCookieValue('access_token', cookieRecord);
+    expect(joined).toBe(original);
+  });
+
+  it('returns undefined if the base cookie is missing', () => {
+    const cookies: Record<string, string> = {
+      access_token1: 'chunk',
+    };
+    expect(getJoinedSplitCookieValue('access_token', cookies)).toBeUndefined();
+  });
+
+  it('lists all cookie chunks to delete via startsWith', () => {
+    const names = [
+      'access_token',
+      'access_token1',
+      'access_token2',
+      'id_token',
+      'access_token_payload',
+    ];
+    expect(getSplitCookieNamesToDelete('access_token', names)).toEqual([
+      'access_token',
+      'access_token1',
+      'access_token2',
+      'access_token_payload',
+    ]);
+  });
+});

--- a/lib/sdk/utilities/index.ts
+++ b/lib/sdk/utilities/index.ts
@@ -5,6 +5,7 @@ export { featureFlags, tokenClaims };
 export * from './feature-flags.js';
 export * from './code-challenge.js';
 export * from './random-string.js';
+export * from './split-cookies.js';
 export * from './token-claims.js';
 export * from './token-utils.js';
 export * from './types.js';

--- a/lib/sdk/utilities/split-cookies.ts
+++ b/lib/sdk/utilities/split-cookies.ts
@@ -1,6 +1,8 @@
 import { splitString, storageSettings } from '@kinde/js-utils';
 
-export const MAX_COOKIE_LENGTH = storageSettings.maxLength;
+export const getMaxCookieLength = (): number => {
+  return storageSettings.maxLength;
+};
 
 export type SplitCookie = {
   name: string;
@@ -15,7 +17,7 @@ export type SplitCookie = {
 export const getSplitCookies = (
   cookieName: string,
   cookieValue: string,
-  maxCookieLength: number = storageSettings.maxLength
+  maxCookieLength: number = getMaxCookieLength()
 ): SplitCookie[] => {
   if (!Number.isInteger(maxCookieLength) || maxCookieLength <= 0) {
     throw new Error(

--- a/lib/sdk/utilities/split-cookies.ts
+++ b/lib/sdk/utilities/split-cookies.ts
@@ -1,6 +1,6 @@
-import { splitString } from '@kinde/js-utils';
+import { splitString, storageSettings } from '@kinde/js-utils';
 
-export const MAX_COOKIE_LENGTH = 3000;
+export const MAX_COOKIE_LENGTH = storageSettings.maxLength;
 
 export type SplitCookie = {
   name: string;
@@ -15,7 +15,7 @@ export type SplitCookie = {
 export const getSplitCookies = (
   cookieName: string,
   cookieValue: string,
-  maxCookieLength: number = MAX_COOKIE_LENGTH
+  maxCookieLength: number = storageSettings.maxLength
 ): SplitCookie[] => {
   if (!Number.isInteger(maxCookieLength) || maxCookieLength <= 0) {
     throw new Error(
@@ -46,14 +46,13 @@ export const getJoinedSplitCookieValue = (
 
   let value = '';
   let index = 0;
-  while (true) {
-    const key = `${cookieName}${index === 0 ? '' : String(index)}`;
-    const chunk = cookies[key];
-    if (chunk === undefined) {
-      break;
-    }
+  let key = cookieName;
+  let chunk = cookies[key];
+  while (chunk !== undefined) {
     value += chunk;
     index++;
+    key = `${cookieName}${String(index)}`;
+    chunk = cookies[key];
   }
   return value;
 };

--- a/lib/sdk/utilities/split-cookies.ts
+++ b/lib/sdk/utilities/split-cookies.ts
@@ -17,6 +17,12 @@ export const getSplitCookies = (
   cookieValue: string,
   maxCookieLength: number = MAX_COOKIE_LENGTH
 ): SplitCookie[] => {
+  if (!Number.isInteger(maxCookieLength) || maxCookieLength <= 0) {
+    throw new Error(
+      `maxCookieLength must be a positive integer. Received: ${String(maxCookieLength)}`
+    );
+  }
+
   return splitString(cookieValue, maxCookieLength).map((value, index) => {
     return {
       name: cookieName + (index === 0 ? '' : String(index)),

--- a/lib/sdk/utilities/split-cookies.ts
+++ b/lib/sdk/utilities/split-cookies.ts
@@ -1,0 +1,63 @@
+import { splitString } from '@kinde/js-utils';
+
+export const MAX_COOKIE_LENGTH = 3000;
+
+export type SplitCookie = {
+  name: string;
+  value: string;
+};
+
+/**
+ * Splits a long cookie value into multiple cookies:
+ * - first chunk uses `cookieName`
+ * - subsequent chunks use `cookieName1`, `cookieName2`, ...
+ */
+export const getSplitCookies = (
+  cookieName: string,
+  cookieValue: string,
+  maxCookieLength: number = MAX_COOKIE_LENGTH
+): SplitCookie[] => {
+  return splitString(cookieValue, maxCookieLength).map((value, index) => {
+    return {
+      name: cookieName + (index === 0 ? '' : String(index)),
+      value,
+    };
+  });
+};
+
+/**
+ * Reconstructs a cookie value from split cookies created by `getSplitCookies`.
+ *
+ * If the base cookie (`cookieName`) is missing, `undefined` is returned.
+ */
+export const getJoinedSplitCookieValue = (
+  cookieName: string,
+  cookies: Record<string, string | undefined>
+): string | undefined => {
+  if (cookies[cookieName] === undefined) {
+    return undefined;
+  }
+
+  let value = '';
+  let index = 0;
+  while (true) {
+    const key = `${cookieName}${index === 0 ? '' : String(index)}`;
+    const chunk = cookies[key];
+    if (chunk === undefined) {
+      break;
+    }
+    value += chunk;
+    index++;
+  }
+  return value;
+};
+
+/**
+ * Helper for deleting all cookie chunks for a given base name.
+ */
+export const getSplitCookieNamesToDelete = (
+  cookieName: string,
+  existingCookieNames: string[]
+): string[] => {
+  return existingCookieNames.filter((name) => name.startsWith(cookieName));
+};


### PR DESCRIPTION
Introduce utility functions for splitting long cookie values into multiple cookies and reconstructing them. Include tests to ensure functionality and correctness of the new utilities.

# Explain your changes

This update adds utility functions to handle long cookie values by splitting them into manageable chunks and reconstructing them when needed. Tests validate the functionality of these utilities.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._

