### PR TITLE
fix: keep portal types local to sdk

### DIFF
--- a/lib/sdk/clients/browser/authcode-with-pkce.ts
+++ b/lib/sdk/clients/browser/authcode-with-pkce.ts
@@ -1,7 +1,7 @@
 import { BrowserSessionManager } from '../../session-managers/index.js';
 import { AuthCodeWithPKCE } from '../../oauth2-flows/index.js';
 import * as utilities from '../../utilities/index.js';
-import type { GeneratePortalUrlParams } from '@kinde/js-utils';
+import type { GeneratePortalUrlParams } from '../../portal.js';
 
 import type {
   UserType,

--- a/lib/sdk/clients/server/authorization-code.ts
+++ b/lib/sdk/clients/server/authorization-code.ts
@@ -12,7 +12,7 @@ import type {
 } from '../types.js';
 
 import type { OAuth2CodeExchangeResponse } from '../../oauth2-flows/types.js';
-import type { GeneratePortalUrlParams } from '@kinde/js-utils';
+import type { GeneratePortalUrlParams } from '../../portal.js';
 
 const createAuthorizationCodeClient = (
   options: ACClientOptions,

--- a/lib/sdk/clients/types.ts
+++ b/lib/sdk/clients/types.ts
@@ -12,8 +12,8 @@ export interface BrowserPKCEClientOptions extends AuthorizationCodeOptions {
   sessionManager?: SessionManager;
 }
 
-export { PortalPage } from '@kinde/js-utils';
-export type { GeneratePortalUrlParams } from '@kinde/js-utils';
+export { PortalPage } from '../portal.js';
+export type { GeneratePortalUrlParams } from '../portal.js';
 
 export interface PKCEClientOptions extends AuthorizationCodeOptions {}
 export interface CCClientOptions extends ClientCredentialsOptions {}

--- a/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeAbstract.ts
@@ -11,7 +11,7 @@ import type {
   AuthorizationCodeOptions,
   AuthURLOptions,
 } from './types.js';
-import type { GeneratePortalUrlParams } from '@kinde/js-utils';
+import type { GeneratePortalUrlParams } from '../portal.js';
 
 /**
  * Abstract class provides contract (methods) for classes implementing OAuth2.0 flows

--- a/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
+++ b/lib/sdk/oauth2-flows/AuthCodeWithPKCE.ts
@@ -12,7 +12,7 @@ import type {
   AuthURLOptions,
   AuthorizationCodeOptions,
 } from './types.js';
-import type { GeneratePortalUrlParams } from '@kinde/js-utils';
+import type { GeneratePortalUrlParams } from '../portal.js';
 import { createPortalUrl } from '../utilities/createPortalUrl.js';
 
 /**

--- a/lib/sdk/oauth2-flows/AuthorizationCode.ts
+++ b/lib/sdk/oauth2-flows/AuthorizationCode.ts
@@ -7,7 +7,7 @@ import type {
   AuthorizationCodeOptions,
   AuthURLOptions,
 } from './types.js';
-import type { GeneratePortalUrlParams } from '@kinde/js-utils';
+import type { GeneratePortalUrlParams } from '../portal.js';
 import { createPortalUrl } from '../utilities/createPortalUrl.js';
 
 /**

--- a/lib/sdk/portal.ts
+++ b/lib/sdk/portal.ts
@@ -1,0 +1,16 @@
+export enum PortalPage {
+  organizationDetails = 'organization_details',
+  organizationMembers = 'organization_members',
+  organizationPlanDetails = 'organization_plan_details',
+  organizationPaymentDetails = 'organization_payment_details',
+  organizationPlanSelection = 'organization_plan_selection',
+  paymentDetails = 'payment_details',
+  planSelection = 'plan_selection',
+  planDetails = 'plan_details',
+}
+
+export interface GeneratePortalUrlParams {
+  domain?: string;
+  returnUrl: string;
+  subNav?: PortalPage;
+}

--- a/lib/sdk/utilities/createPortalUrl.ts
+++ b/lib/sdk/utilities/createPortalUrl.ts
@@ -4,7 +4,7 @@ import {
   setActiveStorage,
   StorageKeys,
 } from '@kinde/js-utils';
-import type { GeneratePortalUrlParams } from '@kinde/js-utils';
+import type { GeneratePortalUrlParams } from '../portal.js';
 import { type SessionManager } from '../session-managers/index.js';
 
 export const createPortalUrl = async (


### PR DESCRIPTION
# Explain your changes

Fixes #176.

This keeps the SDK's public portal types inside this package instead of re-exporting them from `@kinde/js-utils`.

The published SDK declarations currently expose `PortalPage` and `GeneratePortalUrlParams` through `@kinde/js-utils`, and some emitted declarations can point at `@kinde/js-utils/dist/types.js`. In a clean NodeNext TypeScript consumer with `skipLibCheck: false`, those declarations fail because the dependent package type surface is not NodeNext-safe for those exported types.

This PR:
- Adds local SDK-owned `PortalPage` and `GeneratePortalUrlParams` definitions.
- Re-exports those local portal types from the existing clients type surface.
- Updates internal portal method signatures to use the SDK-owned type.
- Leaves runtime behavior unchanged; `createPortalUrl` still calls `generatePortalUrl` from `@kinde/js-utils`.

# Verification

- `corepack pnpm exec tsc --noEmit`
- Generated declarations with `corepack pnpm exec tsc` and `corepack pnpm exec tsc -p tsconfig.cjs.json`.
- Confirmed generated declarations no longer reference `@kinde/js-utils` or `@kinde/js-utils/dist/types.js`.

I could not run the full `pnpm run build` in this local environment because the OpenAPI generation step requires Java, which is not available here.