### PR TITLE
Point bugs metadata to issue tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "type": "git",
     "url": "https://github.com/kinde-oss/kinde-typescript-sdk"
   },
-  "bugs": "https://github.com/kinde-oss/kinde-typescript-sdk",
+  "bugs": {
+    "url": "https://github.com/kinde-oss/kinde-typescript-sdk/issues"
+  },
   "homepage": "https://kinde.com",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- change npm `bugs` metadata from the repository root to the GitHub issue tracker
- use the standard `bugs.url` object form
- leave runtime code, generated files, dependencies, and package version unchanged

## Validation
- `node -e "const p=require('./package.json'); if (p.name !== '@kinde-oss/kinde-typescript-sdk' || p.bugs?.url !== 'https://github.com/kinde-oss/kinde-typescript-sdk/issues') process.exit(1); console.log(JSON.stringify({name:p.name,bugs:p.bugs}))"`
- `npm pack --dry-run --json --ignore-scripts`
- `git diff --check`