### PR TITLE
fix: update bugs url to point to issues tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "type": "git",
     "url": "https://github.com/kinde-oss/kinde-typescript-sdk"
   },
-  "bugs": "https://github.com/kinde-oss/kinde-typescript-sdk",
+  "bugs": "https://github.com/kinde-oss/kinde-typescript-sdk/issues",
   "homepage": "https://kinde.com",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
 Updated the `bugs` URL in `package.json` to point directly to the repository's issues tracker.